### PR TITLE
Support 'dot_all' flag.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regress"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["ridiculousfish <corydoras@ridiculousfish.com>"]
 description = "A regular expression engine targeting EcmaScript syntax"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ backend-pikevm = []
 
 # Prohibits all uses of unsafe code, for the paranoid.
 prohibit-unsafe = []
+
+[dependencies]
+memchr = "2.3.3"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ There's lots of stuff still missing, maybe you want to contribute?
 - An API for replacing a string while substituting in capture groups (e.g. with `$1`)
 - An API for escaping a string to make it a literal
 - Implementing `std::str::pattern::Pattern`
-- The `s` flag ("DotAll")
 - The `tester` binary needs some real usage.
 
 ### Missing Performance Optimizations

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ oh no why
 
 regress is a backtracking regular expression engine implemented in Rust, which targets JavaScript regular expression syntax. See [the crate documentation](https://docs.rs/regress) for more.
 
-It's fast, Unicode-aware, has no dependencies outside of `std`, and has a big test suite. It makes fewer guarantees than the `regex` crate but it enables more syntactic features, such as backreferences and lookaround assertions.
+It's fast, Unicode-aware, has few dependencies, and has a big test suite. It makes fewer guarantees than the `regex` crate but it enables more syntactic features, such as backreferences and lookaround assertions.
 
 ## Usage
 
@@ -26,6 +26,10 @@ The `tester` binary can be used for some fun.
 You can see how things get compiled with the `dump-phases` crate feature:
 
     > cargo run --features dump-phases --bin tester 'x{3,4}' 'i'
+
+You can run a little benchmark too, for example:
+
+    > cargo run --release --bin tester 'abcd' 'i' --file ~/3200.txt
 
 
 ## Want to contribute?

--- a/perf.md
+++ b/perf.md
@@ -1,158 +1,192 @@
-These are perf results from 5/24/20, from [regex-performance](github.com/rust-leipzig/regex-performance.git).
+These are perf results from 5/25/20, from [regex-performance](github.com/rust-leipzig/regex-performance.git).
 
 ```
 '../3200.txt' loaded. (Length: 16013977 bytes)
 -----------------
 Regex: 'Twain'
-[      pcre] time:     1.6 ms (+/-  4.8 %), matches:      811
-[  pcre-dfa] time:     8.5 ms (+/-  0.6 %), matches:      811
-[  pcre-jit] time:     9.9 ms (+/-  0.8 %), matches:      811
-[       re2] time:     1.1 ms (+/-  5.3 %), matches:      811
-[      onig] time:    10.9 ms (+/-  0.5 %), matches:      811
-[rust_regex] time:     1.1 ms (+/-  3.3 %), matches:      811
-[   regress] time:     5.6 ms (+/-  0.9 %), matches:      811
+[      pcre] time:     1.6 ms (+/-  6.8 %), matches:      811
+[  pcre-dfa] time:     8.4 ms (+/-  1.3 %), matches:      811
+[  pcre-jit] time:     9.9 ms (+/-  0.3 %), matches:      811
+[       re2] time:     1.1 ms (+/-  3.6 %), matches:      811
+[      onig] time:    11.0 ms (+/-  1.1 %), matches:      811
+[       tre] time:   141.0 ms (+/-  0.1 %), matches:      811
+[     hscan] time:     0.7 ms (+/-  3.2 %), matches:      811
+[rust_regex] time:     1.1 ms (+/-  3.1 %), matches:      811
+[rust_regrs] time:     7.1 ms (+/-  1.0 %), matches:      811
 -----------------
 Regex: '(?i)Twain'
-[      pcre] time:    28.5 ms (+/-  0.4 %), matches:      965
-[  pcre-dfa] time:    40.8 ms (+/-  0.6 %), matches:      965
-[  pcre-jit] time:    10.1 ms (+/-  0.7 %), matches:      965
-[       re2] time:    32.1 ms (+/-  0.4 %), matches:      965
-[      onig] time:    45.9 ms (+/-  0.3 %), matches:      965
-[rust_regex] time:    10.3 ms (+/-  0.5 %), matches:      965
-[   regress] time:    21.6 ms (+/-  0.7 %), matches:      965
+[      pcre] time:    28.4 ms (+/-  0.5 %), matches:      965
+[  pcre-dfa] time:    41.0 ms (+/-  1.2 %), matches:      965
+[  pcre-jit] time:    10.1 ms (+/-  1.0 %), matches:      965
+[       re2] time:    32.0 ms (+/-  0.4 %), matches:      965
+[      onig] time:    46.6 ms (+/-  0.4 %), matches:      965
+[       tre] time:   184.6 ms (+/-  0.1 %), matches:      965
+[     hscan] time:     0.9 ms (+/- 10.5 %), matches:      965
+[rust_regex] time:     1.5 ms (+/-  3.3 %), matches:      965
+[rust_regrs] time:    11.0 ms (+/-  1.1 %), matches:      965
 -----------------
 Regex: '[a-z]shing'
-[      pcre] time:   183.3 ms (+/-  0.6 %), matches:     1540
-[  pcre-dfa] time:   312.1 ms (+/-  0.1 %), matches:     1540
-[  pcre-jit] time:     9.3 ms (+/-  0.7 %), matches:     1540
-[       re2] time:    52.0 ms (+/-  0.5 %), matches:     1540
+[      pcre] time:   183.2 ms (+/-  0.4 %), matches:     1540
+[  pcre-dfa] time:   314.4 ms (+/-  0.1 %), matches:     1540
+[  pcre-jit] time:     9.3 ms (+/-  1.0 %), matches:     1540
+[       re2] time:    52.2 ms (+/-  0.6 %), matches:     1540
 [      onig] time:     9.3 ms (+/-  0.6 %), matches:     1540
-[rust_regex] time:     3.4 ms (+/-  2.1 %), matches:     1540
-[   regress] time:   128.0 ms (+/-  0.1 %), matches:     1540
+[       tre] time:   207.8 ms (+/-  0.1 %), matches:     1540
+[     hscan] time:     2.5 ms (+/-  3.7 %), matches:     1540
+[rust_regex] time:     3.5 ms (+/-  2.8 %), matches:     1540
+[rust_regrs] time:   132.4 ms (+/-  0.2 %), matches:     1540
 -----------------
 Regex: 'Huck[a-zA-Z]+|Saw[a-zA-Z]+'
-[      pcre] time:    10.3 ms (+/-  0.7 %), matches:      262
-[  pcre-dfa] time:    10.8 ms (+/-  0.9 %), matches:      262
-[  pcre-jit] time:     1.4 ms (+/-  3.3 %), matches:      262
-[       re2] time:    23.0 ms (+/-  0.3 %), matches:      262
-[      onig] time:    19.1 ms (+/-  0.4 %), matches:      262
-[rust_regex] time:     1.4 ms (+/-  3.7 %), matches:      262
-[   regress] time:     7.8 ms (+/-  0.6 %), matches:      262
+[      pcre] time:    10.4 ms (+/-  1.9 %), matches:      262
+[  pcre-dfa] time:    10.9 ms (+/-  1.0 %), matches:      262
+[  pcre-jit] time:     1.4 ms (+/-  4.0 %), matches:      262
+[       re2] time:    22.9 ms (+/-  1.2 %), matches:      262
+[      onig] time:    19.4 ms (+/-  1.2 %), matches:      262
+[       tre] time:   204.2 ms (+/-  0.1 %), matches:      262
+[     hscan] time:     1.3 ms (+/-  1.1 %), matches:      977
+[rust_regex] time:     1.4 ms (+/-  4.3 %), matches:      262
+[rust_regrs] time:     1.6 ms (+/-  3.2 %), matches:      262
 -----------------
 Regex: '\b\w+nn\b'
-[      pcre] time:   269.4 ms (+/-  0.5 %), matches:      262
+[      pcre] time:   269.1 ms (+/-  0.3 %), matches:      262
 [  pcre-dfa] time:   435.1 ms (+/-  0.1 %), matches:      262
-[  pcre-jit] time:    51.3 ms (+/-  0.3 %), matches:      262
-[       re2] time:    19.8 ms (+/-  1.5 %), matches:      262
-[      onig] time:   333.6 ms (+/-  0.3 %), matches:      262
-[rust_regex] time:   101.5 ms (+/-  0.5 %), matches:      262
-[   regress] time:   195.5 ms (+/-  0.1 %), matches:      262
+[  pcre-jit] time:    51.4 ms (+/-  0.3 %), matches:      262
+[       re2] time:    19.6 ms (+/-  0.7 %), matches:      262
+[      onig] time:   327.9 ms (+/-  0.1 %), matches:      262
+[       tre] time:   344.2 ms (+/-  1.8 %), matches:      262
+[     hscan] time:    66.4 ms (+/-  0.3 %), matches:      262
+[rust_regex] time:   100.4 ms (+/-  0.4 %), matches:      262
+[rust_regrs] time:   191.5 ms (+/-  0.1 %), matches:      262
 -----------------
 Regex: '[a-q][^u-z]{13}x'
-[      pcre] time:   230.1 ms (+/-  0.1 %), matches:     4094
-[  pcre-dfa] time:   842.2 ms (+/-  0.1 %), matches:     4094
-[  pcre-jit] time:     1.0 ms (+/-  7.5 %), matches:     4094
-[       re2] time:   102.8 ms (+/-  7.9 %), matches:     4094
-[      onig] time:    22.9 ms (+/-  1.3 %), matches:     4094
-[rust_regex] time:  1666.2 ms (+/-  1.6 %), matches:     4094
-[   regress] time:   382.8 ms (+/-  0.1 %), matches:     4094
+[      pcre] time:   229.4 ms (+/-  0.2 %), matches:     4094
+[  pcre-dfa] time:   838.4 ms (+/-  0.2 %), matches:     4094
+[  pcre-jit] time:     1.1 ms (+/- 10.3 %), matches:     4094
+[       re2] time:   103.9 ms (+/-  9.5 %), matches:     4094
+[      onig] time:    22.8 ms (+/-  0.3 %), matches:     4094
+[       tre] time:   518.4 ms (+/-  0.1 %), matches:     4094
+[     hscan] time:    36.6 ms (+/-  0.2 %), matches:     4094
+[rust_regex] time:  1578.3 ms (+/-  1.8 %), matches:     4094
+[rust_regrs] time:   358.9 ms (+/-  0.2 %), matches:     4094
 -----------------
 Regex: 'Tom|Sawyer|Huckleberry|Finn'
-[      pcre] time:    13.3 ms (+/-  1.6 %), matches:     2598
-[  pcre-dfa] time:    14.3 ms (+/-  0.8 %), matches:     2598
-[  pcre-jit] time:    14.9 ms (+/-  0.3 %), matches:     2598
-[       re2] time:    23.9 ms (+/-  0.7 %), matches:     2598
-[      onig] time:    22.0 ms (+/-  0.4 %), matches:     2598
-[rust_regex] time:    24.8 ms (+/-  0.3 %), matches:     2598
-[   regress] time:    11.5 ms (+/-  1.2 %), matches:     2598
+[      pcre] time:    13.2 ms (+/-  1.1 %), matches:     2598
+[  pcre-dfa] time:    14.3 ms (+/-  0.4 %), matches:     2598
+[  pcre-jit] time:    14.9 ms (+/-  0.6 %), matches:     2598
+[       re2] time:    23.9 ms (+/-  0.6 %), matches:     2598
+[      onig] time:    22.0 ms (+/-  0.6 %), matches:     2598
+[       tre] time:   338.2 ms (+/-  0.1 %), matches:     2598
+[     hscan] time:     1.6 ms (+/-  1.1 %), matches:     2598
+[rust_regex] time:     1.4 ms (+/-  2.9 %), matches:     2598
+[rust_regrs] time:    11.7 ms (+/-  0.7 %), matches:     2598
 -----------------
 Regex: '(?i)Tom|Sawyer|Huckleberry|Finn'
-[      pcre] time:   134.6 ms (+/-  0.1 %), matches:     4152
-[  pcre-dfa] time:   163.5 ms (+/-  0.3 %), matches:     4152
-[  pcre-jit] time:    40.8 ms (+/-  0.5 %), matches:     4152
-[       re2] time:    48.1 ms (+/-  0.1 %), matches:     4152
-[      onig] time:   142.0 ms (+/-  0.2 %), matches:     4152
-[rust_regex] time:    25.3 ms (+/-  0.6 %), matches:     4152
-[   regress] time:   113.3 ms (+/-  1.7 %), matches:     4152
+[      pcre] time:   132.6 ms (+/-  0.4 %), matches:     4152
+[  pcre-dfa] time:   161.6 ms (+/-  0.2 %), matches:     4152
+[  pcre-jit] time:    40.7 ms (+/-  0.9 %), matches:     4152
+[       re2] time:    48.0 ms (+/-  0.4 %), matches:     4152
+[      onig] time:   140.3 ms (+/-  0.1 %), matches:     4152
+[       tre] time:   491.6 ms (+/-  0.1 %), matches:     4152
+[     hscan] time:     1.7 ms (+/-  7.4 %), matches:     4152
+[rust_regex] time:     2.8 ms (+/-  3.1 %), matches:     4152
+[rust_regrs] time:   110.9 ms (+/-  0.2 %), matches:     4152
 -----------------
 Regex: '.{0,2}(Tom|Sawyer|Huckleberry|Finn)'
-[      pcre] time:  1707.2 ms (+/-  0.0 %), matches:     2598
-[  pcre-dfa] time:  1517.7 ms (+/-  0.1 %), matches:     2598
-[  pcre-jit] time:   130.4 ms (+/-  0.2 %), matches:     2598
-[       re2] time:    22.3 ms (+/-  0.7 %), matches:     2598
-[      onig] time:    40.6 ms (+/-  0.4 %), matches:     2598
-[rust_regex] time:    21.4 ms (+/-  1.2 %), matches:     2598
-[   regress] time:   969.3 ms (+/-  0.0 %), matches:     2598
+[      pcre] time:  1613.8 ms (+/-  0.0 %), matches:     2598
+[  pcre-dfa] time:  1514.8 ms (+/-  0.2 %), matches:     2598
+[  pcre-jit] time:   129.9 ms (+/-  0.3 %), matches:     2598
+[       re2] time:    22.2 ms (+/-  0.6 %), matches:     2598
+[      onig] time:    40.6 ms (+/-  0.9 %), matches:     2598
+[       tre] time:  1087.0 ms (+/-  0.8 %), matches:     2598
+[     hscan] time:     1.6 ms (+/-  0.8 %), matches:     2598
+[rust_regex] time:    21.4 ms (+/-  0.8 %), matches:     2598
+[rust_regrs] time:   961.8 ms (+/-  1.0 %), matches:     2598
 -----------------
 Regex: '.{2,4}(Tom|Sawyer|Huckleberry|Finn)'
-[      pcre] time:  1664.6 ms (+/-  0.0 %), matches:     1976
-[  pcre-dfa] time:  1807.6 ms (+/-  0.0 %), matches:     1976
-[  pcre-jit] time:   142.3 ms (+/-  0.3 %), matches:     1976
-[       re2] time:    22.3 ms (+/-  0.6 %), matches:     1976
-[      onig] time:    38.9 ms (+/-  0.3 %), matches:     1976
-[rust_regex] time:    21.4 ms (+/-  1.5 %), matches:     1976
-[   regress] time:  1024.4 ms (+/-  0.8 %), matches:     1976
+[      pcre] time:  1688.0 ms (+/-  0.0 %), matches:     1976
+[  pcre-dfa] time:  1808.7 ms (+/-  0.1 %), matches:     1976
+[  pcre-jit] time:   141.8 ms (+/-  0.1 %), matches:     1976
+[       re2] time:    22.2 ms (+/-  0.5 %), matches:     1976
+[      onig] time:    38.7 ms (+/-  0.4 %), matches:     1976
+[       tre] time:  1656.9 ms (+/-  0.3 %), matches:     1976
+[     hscan] time:     1.8 ms (+/-  7.2 %), matches:     2598
+[rust_regex] time:    21.3 ms (+/-  1.5 %), matches:     1976
+[rust_regrs] time:   965.6 ms (+/-  0.3 %), matches:     1976
 -----------------
 Regex: 'Tom.{10,25}river|river.{10,25}Tom'
-[      pcre] time:    27.8 ms (+/-  0.8 %), matches:        2
-[  pcre-dfa] time:    35.0 ms (+/-  0.5 %), matches:        2
-[  pcre-jit] time:     8.3 ms (+/-  1.1 %), matches:        2
+[      pcre] time:    27.7 ms (+/-  0.5 %), matches:        2
+[  pcre-dfa] time:    34.9 ms (+/-  0.4 %), matches:        2
+[  pcre-jit] time:     8.3 ms (+/-  1.5 %), matches:        2
 [       re2] time:    27.9 ms (+/-  2.3 %), matches:        2
-[      onig] time:    37.7 ms (+/-  0.5 %), matches:        2
-[rust_regex] time:     8.5 ms (+/-  7.0 %), matches:        2
-[   regress] time:    18.7 ms (+/-  0.6 %), matches:        2
+[      onig] time:    37.3 ms (+/-  0.4 %), matches:        2
+[       tre] time:   244.5 ms (+/-  0.1 %), matches:        2
+[     hscan] time:     1.3 ms (+/-  2.1 %), matches:        4
+[rust_regex] time:     1.9 ms (+/- 23.8 %), matches:        2
+[rust_regrs] time:     9.9 ms (+/-  0.5 %), matches:        2
 -----------------
 Regex: '[a-zA-Z]+ing'
-[      pcre] time:   399.2 ms (+/-  0.1 %), matches:    78424
-[  pcre-dfa] time:   718.4 ms (+/-  0.0 %), matches:    78424
-[  pcre-jit] time:    44.5 ms (+/-  0.6 %), matches:    78424
-[       re2] time:    59.0 ms (+/-  0.2 %), matches:    78424
-[      onig] time:   341.2 ms (+/-  0.1 %), matches:    78424
-[rust_regex] time:     8.8 ms (+/-  0.5 %), matches:    78424
-[   regress] time:   300.0 ms (+/-  0.1 %), matches:    78424
+[      pcre] time:   398.0 ms (+/-  0.1 %), matches:    78424
+[  pcre-dfa] time:   717.5 ms (+/-  0.1 %), matches:    78424
+[  pcre-jit] time:    44.4 ms (+/-  0.4 %), matches:    78424
+[       re2] time:    59.2 ms (+/-  0.2 %), matches:    78424
+[      onig] time:   338.3 ms (+/-  0.0 %), matches:    78424
+[       tre] time:   265.1 ms (+/-  0.1 %), matches:    78424
+[     hscan] time:     9.6 ms (+/-  1.7 %), matches:    78872
+[rust_regex] time:     9.1 ms (+/-  1.1 %), matches:    78424
+[rust_regrs] time:   295.3 ms (+/-  0.1 %), matches:    78424
 -----------------
 Regex: '\s[a-zA-Z]{0,12}ing\s'
-[      pcre] time:   181.7 ms (+/-  0.2 %), matches:    55248
-[  pcre-dfa] time:   278.7 ms (+/-  0.2 %), matches:    55248
-[  pcre-jit] time:    56.2 ms (+/-  0.3 %), matches:    55248
-[       re2] time:    33.2 ms (+/-  0.7 %), matches:    55248
-[      onig] time:    37.7 ms (+/-  0.4 %), matches:    55248
+[      pcre] time:   180.9 ms (+/-  0.2 %), matches:    55248
+[  pcre-dfa] time:   278.2 ms (+/-  0.1 %), matches:    55248
+[  pcre-jit] time:    56.4 ms (+/-  0.5 %), matches:    55248
+[       re2] time:    33.4 ms (+/-  0.5 %), matches:    55248
+[      onig] time:    39.2 ms (+/-  0.4 %), matches:    55248
+[       tre] time:   370.6 ms (+/-  0.1 %), matches:    55248
+[     hscan] time:    13.2 ms (+/-  1.2 %), matches:    55640
 [rust_regex] time:    24.7 ms (+/-  0.7 %), matches:    55248
-[   regress] time:   153.1 ms (+/-  0.1 %), matches:    55248
+[rust_regrs] time:   151.3 ms (+/-  0.1 %), matches:    55248
 -----------------
 Regex: '([A-Za-z]awyer|[A-Za-z]inn)\s'
-[      pcre] time:   378.3 ms (+/-  0.1 %), matches:      209
-[  pcre-dfa] time:   494.2 ms (+/-  0.1 %), matches:      209
-[  pcre-jit] time:    20.3 ms (+/-  1.0 %), matches:      209
-[       re2] time:    49.8 ms (+/-  0.3 %), matches:      209
-[      onig] time:    90.5 ms (+/-  0.5 %), matches:      209
-[rust_regex] time:    21.1 ms (+/-  0.4 %), matches:      209
-[   regress] time:   228.5 ms (+/-  0.1 %), matches:      209
+[      pcre] time:   377.8 ms (+/-  0.1 %), matches:      209
+[  pcre-dfa] time:   493.5 ms (+/-  0.1 %), matches:      209
+[  pcre-jit] time:    20.3 ms (+/-  0.9 %), matches:      209
+[       re2] time:    49.7 ms (+/-  0.5 %), matches:      209
+[      onig] time:    90.5 ms (+/-  0.2 %), matches:      209
+[       tre] time:   407.0 ms (+/-  0.1 %), matches:      209
+[     hscan] time:     2.9 ms (+/-  4.2 %), matches:      209
+[rust_regex] time:    21.1 ms (+/-  0.6 %), matches:      209
+[rust_regrs] time:   229.7 ms (+/-  0.1 %), matches:      209
 -----------------
 Regex: '["'][^"']{0,30}[?!\.]["']'
-[      pcre] time:    25.0 ms (+/-  1.0 %), matches:     8886
-[  pcre-dfa] time:    37.2 ms (+/-  0.4 %), matches:     8886
-[  pcre-jit] time:     5.6 ms (+/-  1.9 %), matches:     8886
-[       re2] time:    24.7 ms (+/-  0.6 %), matches:     8886
-[      onig] time:    35.0 ms (+/-  0.3 %), matches:     8886
-[rust_regex] time:     5.7 ms (+/-  5.4 %), matches:     8886
-[   regress] time:    24.9 ms (+/-  0.5 %), matches:     8886
+[      pcre] time:    25.0 ms (+/-  1.1 %), matches:     8886
+[  pcre-dfa] time:    36.9 ms (+/-  0.3 %), matches:     8886
+[  pcre-jit] time:     5.5 ms (+/-  1.3 %), matches:     8886
+[       re2] time:    24.7 ms (+/-  0.7 %), matches:     8886
+[      onig] time:    35.1 ms (+/-  0.2 %), matches:     8886
+[       tre] time:   202.6 ms (+/-  0.2 %), matches:     8886
+[     hscan] time:     8.1 ms (+/-  1.8 %), matches:     8898
+[rust_regex] time:     5.7 ms (+/-  4.9 %), matches:     8886
+[rust_regrs] time:    16.9 ms (+/-  0.5 %), matches:     8886
 -----------------
 Regex: '∞|✓'
-[      pcre] time:     0.5 ms (+/-  9.5 %), matches:        2
-[  pcre-dfa] time:     7.1 ms (+/-  0.7 %), matches:        2
-[  pcre-jit] time:     0.8 ms (+/-  7.8 %), matches:        2
-[       re2] time:     0.5 ms (+/-  8.0 %), matches:        0
-[      onig] time:    21.2 ms (+/-  0.6 %), matches:        2
-[rust_regex] time:    24.7 ms (+/-  0.4 %), matches:        2
-[   regress] time:     5.9 ms (+/-  2.4 %), matches:        2
+[      pcre] time:     0.6 ms (+/- 12.9 %), matches:        2
+[  pcre-dfa] time:     7.1 ms (+/-  1.7 %), matches:        2
+[  pcre-jit] time:     0.8 ms (+/-  8.5 %), matches:        2
+[       re2] time:     0.5 ms (+/-  9.5 %), matches:        0
+[      onig] time:    21.5 ms (+/-  0.1 %), matches:        2
+[       tre] time:   168.0 ms (+/-  0.2 %), matches:        2
+[     hscan] time:     1.2 ms (+/-  9.9 %), matches:        2
+[rust_regex] time:     1.3 ms (+/-  2.4 %), matches:        2
+[rust_regrs] time:     0.5 ms (+/- 11.8 %), matches:        2
 -----------------
 Total Results:
-[      pcre] time:   5255.3 ms, score:     11 points,
-[  pcre-dfa] time:   6723.1 ms, score:      3 points,
-[  pcre-jit] time:    547.1 ms, score:     48 points,
-[       re2] time:    542.4 ms, score:     41 points,
-[      onig] time:   1248.4 ms, score:     17 points,
-[rust_regex] time:   1970.4 ms, score:     58 points,
-[   regress] time:   3590.8 ms, score:     14 points,
+[      pcre] time:   5179.7 ms, score:      3 points,
+[  pcre-dfa] time:   6715.7 ms, score:      0 points,
+[  pcre-jit] time:    546.2 ms, score:     33 points,
+[       re2] time:    543.5 ms, score:     23 points,
+[      onig] time:   1240.5 ms, score:      7 points,
+[       tre] time:   6831.5 ms, score:      0 points,
+[     hscan] time:    151.3 ms, score:     67 points,
+[rust_regex] time:   1796.8 ms, score:     52 points,
+[rust_regrs] time:   3456.0 ms, score:      7 points,
 ```

--- a/src/api.rs
+++ b/src/api.rs
@@ -25,6 +25,10 @@ pub struct Flags {
     /// Equivalent to the 'm' flag in JavaScript.
     pub multiline: bool,
 
+    /// If set, . matches at line separators as well as any other character.
+    /// Equivalent to the 'm' flag in JavaScript.
+    pub dot_all: bool,
+
     /// If set, disable regex IR passes.
     pub no_opt: bool,
 
@@ -55,6 +59,9 @@ impl Flags {
                 }
                 'i' => {
                     result.icase = true;
+                }
+                's' => {
+                    result.dot_all = true;
                 }
                 _ => {
                     // Silently skip unsupported flags.

--- a/src/classicalbacktrack.rs
+++ b/src/classicalbacktrack.rs
@@ -238,6 +238,7 @@ impl<'a> MatchAttempter<'a> {
             Insn::AsciiBracket(bitmap) => {
                 self.run_scm_loop_impl(scm::MatchByteSet { bytes: bitmap }, min, max, *pos, cursor)
             }
+            Insn::MatchAny => self.run_scm_loop_impl(scm::MatchAny::new(), min, max, *pos, cursor),
             Insn::MatchAnyExceptLineTerminator => self.run_scm_loop_impl(
                 scm::MatchAnyExceptLineTerminator::new(),
                 min,
@@ -575,6 +576,8 @@ impl<'a> MatchAttempter<'a> {
                     }
 
                     Insn::Bracket(bc) => next_or_bt!(scm::Bracket { bc }.matches(&mut pos, cursor)),
+
+                    Insn::MatchAny => next_or_bt!(scm::MatchAny::new().matches(&mut pos, cursor)),
 
                     Insn::MatchAnyExceptLineTerminator => next_or_bt!(
                         scm::MatchAnyExceptLineTerminator::new().matches(&mut pos, cursor)

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -129,6 +129,7 @@ impl Emitter {
                     self.emit_insn(Insn::Bracket(contents.clone()))
                 }
             }
+            Node::MatchAny => self.emit_insn(Insn::MatchAny),
             Node::MatchAnyExceptLineTerminator => {
                 self.emit_insn(Insn::MatchAnyExceptLineTerminator)
             }

--- a/src/insn.rs
+++ b/src/insn.rs
@@ -44,6 +44,10 @@ pub enum Insn {
     /// Match the end of a line; emitted by '$'
     EndOfLine,
 
+    /// Match any character except a line terminator; emitted by '.' only when
+    /// the dot_all flag is set to true.
+    MatchAny,
+
     /// Match any character except a line terminator; emitted by '.'
     MatchAnyExceptLineTerminator,
 

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -52,6 +52,9 @@ pub enum Node {
     /// Match an alternation like a|b.
     Alt(Box<Node>, Box<Node>),
 
+    /// Match anything including newlines.
+    MatchAny,
+
     /// Match anything except a newline.
     MatchAnyExceptLineTerminator,
 
@@ -130,6 +133,7 @@ impl Node {
             Node::Char { .. } => true,
             Node::CharSet { .. } => true,
             Node::Bracket { .. } => true,
+            Node::MatchAny => true,
             Node::MatchAnyExceptLineTerminator => true,
             _ => false,
         }
@@ -149,6 +153,7 @@ impl Node {
             Node::Alt(left, right) => {
                 Node::Alt(Box::new(left.duplicate()), Box::new(right.duplicate()))
             }
+            Node::MatchAny => Node::MatchAny,
             Node::MatchAnyExceptLineTerminator => Node::MatchAnyExceptLineTerminator,
             &Node::Anchor(anchor_type) => Node::Anchor(anchor_type),
 
@@ -247,6 +252,7 @@ where
                 self.process(left.as_ref());
                 self.process(right.as_ref());
             }
+            Node::MatchAny => {}
             Node::MatchAnyExceptLineTerminator => {}
             Node::Anchor { .. } => {}
             Node::Loop { loopee, .. } => self.process(loopee),
@@ -315,6 +321,7 @@ where
                 self.process(left.as_mut());
                 self.process(right.as_mut());
             }
+            Node::MatchAny => {}
             Node::MatchAnyExceptLineTerminator => {}
             Node::Anchor { .. } => {}
             Node::Loop { loopee, .. } => {
@@ -441,6 +448,9 @@ fn display_node(node: &Node, depth: usize, f: &mut fmt::Formatter) -> fmt::Resul
         }
         Node::Alt(..) => {
             writeln!(f, "Alt")?;
+        }
+        Node::MatchAny => {
+            writeln!(f, "MatchAny")?;
         }
         Node::MatchAnyExceptLineTerminator => {
             writeln!(f, "MatchAnyExceptLineTerminator")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,10 @@ regress supports features that regex does not, in particular backreferences and 
 However the regex crate provides linear-time matching guarantees, while regress does not. This difference is due
 to the architecture: regex uses finite automata while regress uses "classical backtracking."
 
+# Comparison to fancy-regex crate
+
+fancy-regex wraps the regex crate and extends it with PCRE-style syntactic features. regress has more complete support for these features: backreferences may be case-insensitive, and lookbehinds may be arbitrary-width.
+
 # Architecture
 
 regress has a parser, intermediate representation, optimizer which acts on the IR, bytecode emitter, and two bytecode interpreters, referred to as "backends".

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -133,6 +133,7 @@ fn remove_empties(n: &mut Node, _w: &Walk) -> PassAction {
                 PassAction::Keep
             }
         }
+        Node::MatchAny => PassAction::Keep,
         Node::MatchAnyExceptLineTerminator => PassAction::Keep,
         Node::Anchor { .. } => PassAction::Keep,
         Node::Loop {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -231,7 +231,11 @@ impl<'a> Parser<'a> {
 
                 '.' => {
                     self.consume('.');
-                    result.push(ir::Node::MatchAnyExceptLineTerminator);
+                    result.push(if self.flags.dot_all {
+                        ir::Node::MatchAny
+                    } else {
+                        ir::Node::MatchAnyExceptLineTerminator
+                    });
                 }
 
                 '(' => {

--- a/src/pikevm.rs
+++ b/src/pikevm.rs
@@ -157,6 +157,11 @@ fn try_match_state<Cursor: Cursorable>(
             nextinsn_or_fail!(matches)
         }
 
+        Insn::MatchAny => match cursor.next(&mut s.pos) {
+            Some(_) => nextinsn_or_fail!(true),
+            _ => StateMatch::Fail,
+        },
+
         Insn::MatchAnyExceptLineTerminator => match cursor.next(&mut s.pos) {
             Some(c2) => nextinsn_or_fail!(!Cursor::CharProps::is_line_terminator(c2)),
             _ => StateMatch::Fail,

--- a/src/scm.rs
+++ b/src/scm.rs
@@ -70,6 +70,21 @@ impl<'a, Cursor: Cursorable> SingleCharMatcher<Cursor> for Bracket<'a> {
     }
 }
 
+/// Insn::MatchAny
+pub struct MatchAny {}
+impl MatchAny {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+impl<Cursor: Cursorable> SingleCharMatcher<Cursor> for MatchAny {
+    #[inline(always)]
+    fn matches(&self, pos: &mut Position, cursor: Cursor) -> bool {
+        // If there is a character, it counts as a match.
+        cursor.next(pos).is_some()
+    }
+}
+
 /// Insn::MatchAnyExceptLineTerminator
 pub struct MatchAnyExceptLineTerminator {}
 impl MatchAnyExceptLineTerminator {

--- a/src/startpredicate.rs
+++ b/src/startpredicate.rs
@@ -150,6 +150,9 @@ fn compute_start_predicate(n: &Node) -> Option<AbstractStartPredicate> {
         // Cats return the first non-None value, if any.
         Node::Cat(nodes) => nodes.iter().filter_map(compute_start_predicate).next(),
 
+        // MatchAny (aka .) is too common to do a fast prefix search for.
+        Node::MatchAny => arbitrary,
+
         // MatchAnyExceptLineTerminator (aka .) is too common to do a fast prefix search for.
         Node::MatchAnyExceptLineTerminator => arbitrary,
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -64,6 +64,39 @@ fn test_multiline() {
     test_with_configs(test_multiline_tc)
 }
 
+fn test_dotall_tc(tc: TestConfig) {
+    tc.compile(r".").test_fails("\n");
+    tc.compilef(r".", "s").match1f("\n").test_eq("\n");
+
+    tc.compile(r".").test_fails("\r");
+    tc.compilef(r".", "s").match1f("\r").test_eq("\r");
+
+    tc.compile(r".").test_fails("\u{2028}");
+    tc.compilef(r".", "s")
+        .match1f("\u{2028}")
+        .test_eq("\u{2028}");
+
+    tc.compile(r".").test_fails("\u{2029}");
+    tc.compilef(r".", "s")
+        .match1f("\u{2029}")
+        .test_eq("\u{2029}");
+
+    tc.compile("abc.def").test_fails("abc\ndef");
+    tc.compilef("abc.def", "s")
+        .match1f("abc\ndef")
+        .test_eq("abc\ndef");
+
+    tc.compile(".*").match1f("abc\ndef").test_eq("abc");
+    tc.compilef(".*", "s")
+        .match1f("abc\ndef")
+        .test_eq("abc\ndef");
+}
+
+#[test]
+fn test_dotall() {
+    test_with_configs(test_dotall_tc)
+}
+
 fn test_lookbehinds_tc(tc: TestConfig) {
     tc.compilef(r"(?<=efg)..", "")
         .match1f("abcdefghijk123456")


### PR DESCRIPTION
The 'dot_all' flag (`s` in JavaScript) allows the `.` to match
any character including newlines.

We add an IR node, a bytecode instruction, and a SingleCharMatcher
called `MatchAny` which largely mirrors the behavior of
`MatchAnyExceptNewline` except allows some minor simplifications as we
no longer need to actually look at characters before matching on them.

Closes #1.