### PR TITLE
Implement `std::error::Error` and extra derives for `regress::Error`

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -8,20 +8,23 @@ use crate::ir;
 use crate::types::{
     BracketContents, CaptureGroupID, CharacterClassType, MAX_CAPTURE_GROUPS, MAX_LOOPS,
 };
-use std::fmt;
-use std::iter::Peekable;
+use std::{error::Error as StdError, fmt, iter::Peekable};
 
 /// Represents an error encountered during regex compilation.
+///
 /// The text contains a human-readable error message.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Error {
     pub text: String,
 }
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(&self.text)
     }
 }
+
+impl StdError for Error {}
 
 enum ClassAtom {
     CodePoint(char),


### PR DESCRIPTION
Changes:
 - Implements `std::error::Error` on `regress::Error` as described in the [Rust API guidelines](https://rust-lang.github.io/api-guidelines) in section Interoperability ([C-GOOD-ERROR](https://rust-lang.github.io/api-guidelines/interoperability.html#c-good-err))
 - Implements extra derives (like `PartialEq`, `Eq`, `Hash`, etc) section Interoperability ([C-COMMON-TRAIS](https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits))

These changes are very common and are usually expected in an API, the biggest being implementing `std::error::Error` which allows so we can return an `Box<dyn std::error::Error>` and crates like `anyhow`, `error-chain` to work. The second one is less important but it is nice to have. Initially implementing `Hash` or `Ord` does not make sense for an `Error`, but there are rare cases where it's needed and having the functionality is nice. One example I can thing of (which maybe kind of contrived) is that if we have a list of regular expressions and we wanted to find what are the error ones we could store all the errors in a `HashSet` (requires `Hash` which requires `PartialEq`, `Eq`) without these traits it would be more difficult to do this we would have to implement a wrapper type or create a type like `regress::Error` that implements them.