### PR TITLE
Rename `Regex::newf` to `Regex::with_flags`

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -183,7 +183,7 @@ impl Regex {
     /// Note that this is rather expensive; prefer to cache a Regex which is
     /// intended to be used more than once.
     pub fn new(pattern: &str) -> Result<Regex, Error> {
-        Self::newf(pattern, Flags::default())
+        Self::with_flags(pattern, Flags::default())
     }
 
     /// Construct a regex by parsing `pattern` with `flags`.
@@ -191,7 +191,7 @@ impl Regex {
     //
     /// Note it is preferable to cache a Regex which is intended to be used more
     /// than once, as the parse may be expensive. For example:
-    pub fn newf(pattern: &str, flags: Flags) -> Result<Regex, Error> {
+    pub fn with_flags(pattern: &str, flags: Flags) -> Result<Regex, Error> {
         let mut ire = parse::try_parse(pattern, flags)?;
 
         #[cfg(feature = "dump-phases")]

--- a/src/bin/tester.rs
+++ b/src/bin/tester.rs
@@ -82,7 +82,7 @@ fn main() -> Result<(), regress::Error> {
         flags.dump_opt_ir = true;
         flags.dump_bytecode = true;
     }
-    let re = regress::Regex::newf(pattern.as_str(), flags)?;
+    let re = regress::Regex::with_flags(pattern.as_str(), flags)?;
 
     loop {
         match args.next() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ regress supports Unicode case folding. For example:
 
 ```rust
 use regress::{Regex, Flags};
-let re = Regex::newf("\u{00B5}", Flags::from("i")).unwrap();
+let re = Regex::with_flags("\u{00B5}", Flags::from("i")).unwrap();
 assert!(re.find("\u{03BC}").is_some());
 ```
 
@@ -88,7 +88,7 @@ Example:
 
 ```rust
 use regress::{Flags, Regex};
-let re = Regex::newf("BC", Flags::from("i")).unwrap();
+let re = Regex::with_flags("BC", Flags::from("i")).unwrap();
 assert!(re.find("abcd").is_some());
 ```
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -170,7 +170,7 @@ impl TestConfig {
         let mut flags = regress::Flags::from(flags_str);
         flags.no_opt = !self.optimize;
 
-        let re = regress::Regex::newf(pattern, flags);
+        let re = regress::Regex::with_flags(pattern, flags);
         assert!(
             re.is_ok(),
             "Failed to parse! flags: {} pattern: {}, error: {}",


### PR DESCRIPTION
Changes:
 - Rename `Regex::newf` to `Regex::with_flags`

This is done because `newf` is not a descriptive name for a function that constructs a regex with flags, a better name is `with_flags()` with makes it clear what the function does and follows the Rust APIs guidelines section Naming ([C-CASE](https://rust-lang.github.io/api-guidelines/naming.html)) which states that the constructor name should be `new` or `with_more_detail` this is the same as `Vec::with_capacity()`, there are cases where it makes sense to use different naming like `File::open` as described in [here](https://rust-lang.github.io/api-guidelines/predictability.html?highlight=file::open#constructors-are-static-inherent-methods-c-ctor)