### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Changes: add dependabot

Dependabot will automatically check for updates in the dependencies (daily) and will create a PR with a version bump for that dependency (that you can merge or not) with makes it easier to manage the dependencies

**NOTE**: same as #12 it requires github actions to be enabled