### PR TITLE
Improve `tester` bin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,13 @@ repository = "https://github.com/ridiculousfish/regress"
 keywords = ["regex", "regexp"]
 edition = "2018"
 readme = "README.md"
+default-run = "tester"
 
 [profile.release]
 
 [features]
-default = ["backend-pikevm"]
-
-# Exposes flags for dumping IR and bytecode, useful for debugging or optimization.
-dump-phases = []
+default = ["backend-pikevm", "cli"]
+cli = ["structopt"]
 
 # Enables the PikeVM backend.
 backend-pikevm = []
@@ -25,3 +24,11 @@ prohibit-unsafe = []
 
 [dependencies]
 memchr = "2.3.3"
+
+# Optional dependencies
+structopt = { version = "0.3", optional = true}
+
+[[bin]]
+name = "tester"
+path = "src/bin/tester.rs"
+required-features = ["cli"]

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ regress = "0.1"
 
 The `tester` binary can be used for some fun.
 
-You can see how things get compiled with the `dump-phases` crate feature:
+You can see how things get compiled with the `dump-all` cli flag:
 
-    > cargo run --features dump-phases --bin tester 'x{3,4}' 'i'
+    > cargo run 'x{3,4}' 'i' --dump-phases
 
 You can run a little benchmark too, for example:
 
-    > cargo run --release --bin tester 'abcd' 'i' --file ~/3200.txt
+    > cargo run --release -- 'abcd' 'i' --bench ~/3200.txt
 
 
 ## Want to contribute?
@@ -49,7 +49,6 @@ There's lots of stuff still missing, maybe you want to contribute?
 - An API for replacing a string while substituting in capture groups (e.g. with `$1`)
 - An API for escaping a string to make it a literal
 - Implementing `std::str::pattern::Pattern`
-- The `tester` binary needs some real usage.
 
 ### Missing Performance Optimizations
 


### PR DESCRIPTION
- Make `tester` the default bin, so we can run `cargo run` instead of `cargo run --bin tester`
- Remove `dump-phase` flag feature.
- Added dump flags for dumping.
- Remove dump flags from `Flags`
- Refactor `tester` to use `structopt` crate
- Fix wrong counting of matches
- Add help message to cli options/flags