### PR TITLE
Comment out the nightly fmt feature

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-wrap_comments = true
+# wrap_comments = true


### PR DESCRIPTION
Rustfmt was generating some warnings about: `wrap_comments` since it is not stabilized and only available in nightly channel. So I'm commenting it out for now until its stable

warnings generated:
```
Warning: can't set `wrap_comments = true`, unstable features are only available in nightly channel.
Warning: can't set `wrap_comments = true`, unstable features are only available in nightly channel.
Warning: can't set `wrap_comments = true`, unstable features are only available in nightly channel.
Warning: can't set `wrap_comments = true`, unstable features are only available in nightly channel.
Warning: can't set `wrap_comments = true`, unstable features are only available in nightly channel.
```
