### PR TITLE
Implement `From<&str>` for Flags and improve `Regex::with_flags`

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -33,13 +33,13 @@ pub struct Flags {
     pub no_opt: bool,
 }
 
-impl Flags {
+impl From<&str> for Flags {
     /// Construct a Flags from a string, using JavaScript field names.
     /// 'i' means to ignore case, 'm' means multiline.
     /// Note the 'g' flag implies a stateful regex and is not supported.
     /// Other flags are not implemented and are ignored.
     #[inline]
-    pub fn from(s: &str) -> Self {
+    fn from(s: &str) -> Self {
         let mut result = Self::default();
         for c in s.chars() {
             match c {
@@ -194,7 +194,11 @@ impl Regex {
     /// Note it is preferable to cache a Regex which is intended to be used more
     /// than once, as the parse may be expensive. For example:
     #[inline]
-    pub fn with_flags(pattern: &str, flags: Flags) -> Result<Regex, Error> {
+    pub fn with_flags<F>(pattern: &str, flags: F) -> Result<Regex, Error>
+    where
+        F: Into<Flags>,
+    {
+        let flags = flags.into();
         let mut ire = parse::try_parse(pattern, flags)?;
         if !flags.no_opt {
             optimizer::optimize(&mut ire);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,8 +62,8 @@ Note the parser assumes the `u` (Unicode) flag, as the non-Unicode path is tied 
 regress supports Unicode case folding. For example:
 
 ```rust
-use regress::{Regex, Flags};
-let re = Regex::with_flags("\u{00B5}", Flags::from("i")).unwrap();
+use regress::Regex;
+let re = Regex::with_flags("\u{00B5}", "i").unwrap();
 assert!(re.find("\u{03BC}").is_some());
 ```
 
@@ -87,8 +87,8 @@ This may provide improved performance if you do not need Unicode semantics, beca
 Example:
 
 ```rust
-use regress::{Flags, Regex};
-let re = Regex::with_flags("BC", Flags::from("i")).unwrap();
+use regress::Regex;
+let re = Regex::with_flags("BC", "i").unwrap();
 assert!(re.find("abcd").is_some());
 ```
 


### PR DESCRIPTION
With having Flags implement `From<&str>` we can make Regex::with_flags accept anything that implements `Into<Flags>` (automatically implemented by From trait),
```rust 
Regex::with_flags("abc", "i")
```
```rust
let flags = Flags::from("i");
Regex::with_flags("abc", flags)
```
This makes the API a bit nicer.