### PR TITLE
Rename `Match::total()` to `Match::range()` and `start` and `end` accessors

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -89,7 +89,7 @@ pub type AsciiMatches<'r, 't> = exec::Matches<backends::DefaultAsciiExecutor<'r,
 pub struct Match {
     /// The total range of the match. Note this may be empty, if the regex
     /// matched an empty string.
-    pub total_range: Range,
+    pub range: Range,
 
     /// The list of captures. This has length equal to the number of capturing
     /// groups in the regex. For each capture, if the value is None, that group
@@ -106,17 +106,31 @@ impl Match {
     #[inline]
     pub fn group(&self, idx: usize) -> Option<Range> {
         if idx == 0 {
-            Some(self.total_range.clone())
+            Some(self.range.clone())
         } else {
             self.captures[idx - 1].clone()
         }
     }
 
-    /// Return the total range. This is a convenience function to work around
+    /// Returns the range over the starting and ending byte offsets of the match in the haystack.
+    ///
+    /// This is a convenience function to work around
     /// the fact that Range does not support Copy.
     #[inline]
-    pub fn total(&self) -> Range {
-        self.total_range.clone()
+    pub fn range(&self) -> Range {
+        self.range.clone()
+    }
+
+    /// Returns the starting byte offset of the match in the haystack.
+    #[inline]
+    pub fn start(&self) -> usize {
+        self.range.start
+    }
+
+    /// Returns the ending byte offset of the match in the haystack.
+    #[inline]
+    pub fn end(&self) -> usize {
+        self.range.end
     }
 
     /// Return an iterator over a Match. The first returned value is the total
@@ -230,9 +244,9 @@ impl Regex {
     ///   use regress::Regex;
     ///   let text = "xyxy";
     ///   let re = Regex::new(r"(?<=x)y").unwrap();
-    ///   let t1 = re.find(&text[1..]).unwrap().total();
+    ///   let t1 = re.find(&text[1..]).unwrap().range();
     ///   assert!(t1 == (2..3));
-    ///   let t2 = re.find_from(text, 1).next().unwrap().total();
+    ///   let t2 = re.find_from(text, 1).next().unwrap().range();
     ///   assert!(t2 == (1..2));
     ///   ```
     #[inline]

--- a/src/bin/tester.rs
+++ b/src/bin/tester.rs
@@ -50,7 +50,7 @@ struct Opt {
 }
 
 fn format_match(r: &regress::Match, input: &str) -> String {
-    let mut result = input[r.total()].to_string();
+    let mut result = input[r.range()].to_string();
     for cg in r.captures.iter() {
         result.push(',');
         if let Some(cg) = cg {

--- a/src/classicalbacktrack.rs
+++ b/src/classicalbacktrack.rs
@@ -839,7 +839,7 @@ impl<'r, Input: InputIndexer> BacktrackExecutor<'r, Input> {
             .map(GroupData::as_range)
             .collect();
         Match {
-            total_range: start..end,
+            range: start..end,
             captures,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ use regress::Regex;
 let re = Regex::new(r"(\w)\1").unwrap();
 let text = "Frankly, Miss Piggy, I don't give a hoot!";
 for m in re.find_iter(text) {
-    println!("{}", &text[m.total()])
+    println!("{}", &text[m.range()])
 }
 // Output: ss
 // Output: gg

--- a/src/pikevm.rs
+++ b/src/pikevm.rs
@@ -318,7 +318,7 @@ fn try_match_state<Cursor: Cursorable>(
 fn successful_match(start: usize, state: &State) -> Match {
     let captures = state.groups.iter().map(GroupData::as_range).collect();
     Match {
-        total_range: start..state.pos.pos,
+        range: start..state.pos.pos,
         captures,
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,7 +6,7 @@ pub fn test_parse_fails(pattern: &str) {
 
 /// Format a Match by inserting commas between all capture groups.
 fn format_match(r: &regress::Match, input: &str) -> String {
-    let mut result = input[r.total()].to_string();
+    let mut result = input[r.range()].to_string();
     for cg in r.captures.iter() {
         result.push(',');
         if let Some(cg) = cg {
@@ -88,7 +88,7 @@ impl TestCompiledRegex {
     pub fn match1_vec<'a, 'b>(&'a self, input: &'b str) -> Vec<Option<&'b str>> {
         let mut result = Vec::new();
         let m: regress::Match = self.find(input).expect("Failed to match");
-        result.push(Some(&input[m.total()]));
+        result.push(Some(&input[m.range()]));
         for cr in m.captures {
             result.push(cr.map(|r| &input[r]));
         }
@@ -110,7 +110,7 @@ impl TestCompiledRegex {
     pub fn match_all_from<'a, 'b>(&'a self, input: &'b str, start: usize) -> Vec<regress::Range> {
         self.matches(input, start)
             .into_iter()
-            .map(move |m| m.total())
+            .map(move |m| m.range())
             .collect()
     }
 
@@ -118,7 +118,7 @@ impl TestCompiledRegex {
     pub fn match_all<'a, 'b>(&'a self, input: &'b str) -> Vec<&'b str> {
         self.matches(input, 0)
             .into_iter()
-            .map(move |m| &input[m.total()])
+            .map(move |m| &input[m.range()])
             .collect()
     }
 


### PR DESCRIPTION
 - Renames `Match::total()` => `Match::range()` - the function name `total` does not describe what it returns.
 - Add `Match::start()`
 - Add `Match::end()`

This matches what the `regex` crate does.