### PR TITLE
Make `Parser` generic to any `u32` iterator

### DIFF
--- a/gen-unicode/src/main.rs
+++ b/gen-unicode/src/main.rs
@@ -59,11 +59,11 @@ fn main() {
     general_category_values::generate_tests(&mut scope_tests);
 
     file_unicode_tables
-        .write_all(&scope.to_string().as_bytes())
+        .write_all(scope.to_string().as_bytes())
         .expect("Failed to write to unicode tables file");
 
     file_tests
-        .write_all(&scope_tests.to_string().as_bytes())
+        .write_all(scope_tests.to_string().as_bytes())
         .expect("Failed to write to tests file");
 
     std::process::Command::new("cargo")

--- a/regress-tool/src/regress-tool.rs
+++ b/regress-tool/src/regress-tool.rs
@@ -64,7 +64,7 @@ fn exec_re_on_string(re: &Regex, input: &str) {
     let mut matches = re.find_iter(input);
     if let Some(res) = matches.next() {
         let count = 1 + matches.count();
-        println!("Match: {}, total: {}", format_match(&res, &input), count);
+        println!("Match: {}, total: {}", format_match(&res, input), count);
     } else {
         println!("No match");
     }
@@ -116,7 +116,7 @@ fn main() -> Result<(), Error> {
             Err(err) => println!("{}: {}", err, path.display()),
         };
     } else if let Some(ref path) = args.bench {
-        bench_re_on_path(&re, &path);
+        bench_re_on_path(&re, path);
     } else {
         for input in args.inputs {
             exec_re_on_string(&re, &input);

--- a/src/bytesearch.rs
+++ b/src/bytesearch.rs
@@ -153,7 +153,7 @@ impl SmallArraySet for [u8; 4] {
 // CharSet helper. Avoid branching in the loop to get good unrolling.
 #[allow(unused_parens)]
 #[inline(always)]
-pub fn charset_contains(set: &[char; MAX_CHAR_SET_LENGTH], c: char) -> bool {
+pub fn charset_contains(set: &[u32; MAX_CHAR_SET_LENGTH], c: u32) -> bool {
     let mut result = false;
     for &v in set.iter() {
         result |= (v == c);

--- a/src/classicalbacktrack.rs
+++ b/src/classicalbacktrack.rs
@@ -757,7 +757,7 @@ impl<'a, Input: InputIndexer> MatchAttempter<'a, Input> {
                         next_or_bt!(matched)
                     }
 
-                    &Insn::LookaheadInsn {
+                    &Insn::Lookahead {
                         negate,
                         start_group,
                         end_group,
@@ -778,7 +778,7 @@ impl<'a, Input: InputIndexer> MatchAttempter<'a, Input> {
                         }
                     }
 
-                    &Insn::LookbehindInsn {
+                    &Insn::Lookbehind {
                         negate,
                         start_group,
                         end_group,
@@ -810,7 +810,7 @@ impl<'a, Input: InputIndexer> MatchAttempter<'a, Input> {
                     Insn::EnterLoop(fields) => {
                         // Entering a loop, not re-entering it.
                         self.s.loops.mat(fields.loop_id as usize).iters = 0;
-                        match self.run_loop(&fields, pos, ip) {
+                        match self.run_loop(fields, pos, ip) {
                             Some(next_ip) => {
                                 ip = next_ip;
                                 continue 'nextinsn;

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -194,14 +194,14 @@ impl Emitter {
                 contents,
             } => {
                 let lookaround = if *backwards {
-                    self.emit_insn_offset(Insn::LookbehindInsn {
+                    self.emit_insn_offset(Insn::Lookbehind {
                         negate: *negate,
                         start_group: *start_group,
                         end_group: *end_group,
                         continuation: 0,
                     })
                 } else {
-                    self.emit_insn_offset(Insn::LookaheadInsn {
+                    self.emit_insn_offset(Insn::Lookahead {
                         negate: *negate,
                         start_group: *start_group,
                         end_group: *end_group,
@@ -215,11 +215,11 @@ impl Emitter {
                 // Fix up the continuation.
                 let next_insn = self.next_offset();
                 match self.get_insn(lookaround) {
-                    Insn::LookbehindInsn {
+                    Insn::Lookbehind {
                         ref mut continuation,
                         ..
                     } => *continuation = next_insn,
-                    Insn::LookaheadInsn {
+                    Insn::Lookahead {
                         ref mut continuation,
                         ..
                     } => *continuation = next_insn,

--- a/src/indexing.rs
+++ b/src/indexing.rs
@@ -12,7 +12,6 @@ pub trait ElementType:
     + Clone
     + std::cmp::Eq
     + std::cmp::Ord
-    + std::convert::Into<char>
     + std::convert::Into<u32>
     + std::convert::TryFrom<u32>
 {
@@ -28,8 +27,15 @@ pub trait ElementType:
     }
 
     #[inline(always)]
-    fn as_char(self) -> char {
+    fn as_u32(self) -> u32 {
         self.into()
+    }
+}
+
+impl ElementType for u32 {
+    #[inline(always)]
+    fn bytelength(self) -> usize {
+        2
     }
 }
 

--- a/src/insn.rs
+++ b/src/insn.rs
@@ -36,10 +36,10 @@ pub enum Insn {
     Goal,
 
     /// Match a single char.
-    Char(char),
+    Char(u32),
 
     /// Match a single char, case-insensitive.
-    CharICase(char),
+    CharICase(u32),
 
     /// Match the start of a line (if multiline); emitted by '^'
     StartOfLine,
@@ -102,7 +102,7 @@ pub enum Insn {
     AsciiBracket(AsciiBitmap),
 
     /// Perform a lookahead assertion.
-    LookaheadInsn {
+    Lookahead {
         negate: bool,
         start_group: CaptureGroupID,
         end_group: CaptureGroupID,
@@ -110,7 +110,7 @@ pub enum Insn {
     },
 
     /// Perform a lookbehind assertion.
-    LookbehindInsn {
+    Lookbehind {
         negate: bool,
         start_group: CaptureGroupID,
         end_group: CaptureGroupID,
@@ -124,7 +124,7 @@ pub enum Insn {
 
     /// Match any of the contained chars
     /// There is no length field; characters are simply duplicated as necessary.
-    CharSet([char; MAX_CHAR_SET_LENGTH]),
+    CharSet([u32; MAX_CHAR_SET_LENGTH]),
 
     /// Match the next byte against some possibilities.
     ByteSet2(ByteArraySet<[u8; 2]>),

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -34,7 +34,7 @@ pub enum Node {
     Goal,
 
     /// Match a literal character.
-    Char { c: char, icase: bool },
+    Char { c: u32, icase: bool },
 
     /// Match a literal sequence of bytes.
     ByteSequence(Vec<u8>),
@@ -45,7 +45,7 @@ pub enum Node {
 
     /// Match any of a sequence of *chars*, case-insensitive.
     /// This may not exceed length MAX_CHAR_SET_LENGTH.
-    CharSet(Vec<char>),
+    CharSet(Vec<u32>),
 
     /// Match the catenation of multiple nodes.
     Cat(Vec<Node>),

--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -18,19 +18,22 @@ pub trait CharProperties {
     /// \return whether this is a word char.
     /// ES9 21.2.2.6.2.
     fn is_word_char(c: Self::Element) -> bool {
-        match c.as_char() {
-            'a'..='z' => true,
-            'A'..='Z' => true,
-            '0'..='9' => true,
-            '_' => true,
+        match char::from_u32(c.as_u32()) {
+            Some('a'..='z') => true,
+            Some('A'..='Z') => true,
+            Some('0'..='9') => true,
+            Some('_') => true,
             _ => false,
         }
     }
 
     /// ES9 11.3
     fn is_line_terminator(c: Self::Element) -> bool {
-        let c = c.as_char();
-        c == '\u{000A}' || c == '\u{000D}' || c == '\u{2028}' || c == '\u{2029}'
+        if let Some(c) = char::from_u32(c.as_u32()) {
+            c == '\u{000A}' || c == '\u{000D}' || c == '\u{2028}' || c == '\u{2029}'
+        } else {
+            false
+        }
     }
 
     /// \return whether the bracket \p bc matches the given character \p c,
@@ -49,7 +52,7 @@ impl CharProperties for UTF8CharProperties {
     type Element = char;
 
     fn fold(c: Self::Element) -> Self::Element {
-        unicode::fold(c)
+        char::from_u32(unicode::fold(c.as_u32())).unwrap()
     }
 }
 

--- a/src/scm.rs
+++ b/src/scm.rs
@@ -44,14 +44,14 @@ impl<Input: InputIndexer, Dir: Direction> SingleCharMatcher<Input, Dir> for Char
 
 /// Insn::CharSet
 pub struct CharSet<'a> {
-    pub chars: &'a [char; MAX_CHAR_SET_LENGTH],
+    pub chars: &'a [u32; MAX_CHAR_SET_LENGTH],
 }
 
 impl<'a, Input: InputIndexer, Dir: Direction> SingleCharMatcher<Input, Dir> for CharSet<'a> {
     #[inline(always)]
     fn matches(&self, input: &Input, dir: Dir, pos: &mut Input::Position) -> bool {
         match cursor::next(input, dir, pos) {
-            Some(c) => charset_contains(self.chars, c.as_char()),
+            Some(c) => charset_contains(self.chars, c.as_u32()),
             None => false,
         }
     }

--- a/src/startpredicate.rs
+++ b/src/startpredicate.rs
@@ -209,7 +209,7 @@ fn compute_start_predicate(n: &Node) -> Option<AbstractStartPredicate> {
             } else {
                 &bc.cps
             };
-            let bitmap = cps_to_first_byte_bitmap(&cps);
+            let bitmap = cps_to_first_byte_bitmap(cps);
             Some(AbstractStartPredicate::Set(bitmap))
         }
 


### PR DESCRIPTION
Mostly related to #43.

This PR makes `Parser` accept any `Iterator<Item = u32>` as its `input` field, which enables parsing unpaired surrogates on UTF-16 based strings.

No changes at the API level since this is mostly an internal change, and I'd like to carefully plan an API that integrates UTF-16 inputs without making breaking changes.

I also took the liberty to fix all the clippy warnings, just to have a cleaner codebase :)