### PR TITLE
feat: Support `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ default-members = ["regress-tool", "."]
 [profile.release]
 
 [features]
-default = ["backend-pikevm"]
+default = ["backend-pikevm", "std"]
+
+std = ["memchr/std"]
 
 # Enables the PikeVM backend.
 backend-pikevm = []
@@ -28,4 +30,5 @@ index-positions = []
 prohibit-unsafe = []
 
 [dependencies]
-memchr = "2.4.0"
+hashbrown = "0.12.0"
+memchr = { version = "2.4.0", default-features = false }

--- a/src/api.rs
+++ b/src/api.rs
@@ -9,9 +9,14 @@ use crate::parse;
 #[cfg(feature = "backend-pikevm")]
 use crate::pikevm;
 
-use std::collections::hash_map::Iter;
-use std::collections::HashMap;
-use std::{fmt, str::FromStr};
+use core::{fmt, str::FromStr};
+#[cfg(feature = "std")]
+use std::collections::{hash_map::Iter, HashMap};
+#[cfg(not(feature = "std"))]
+use {
+    alloc::{string::String, vec::Vec},
+    hashbrown::{hash_map::Iter, HashMap},
+};
 
 pub use parse::Error;
 
@@ -78,7 +83,7 @@ impl fmt::Display for Flags {
 
 /// Range is used to express the extent of a match, as indexes into the input
 /// string.
-pub type Range = std::ops::Range<usize>;
+pub type Range = core::ops::Range<usize>;
 
 /// An iterator type which yields `Match`es found in a string.
 pub type Matches<'r, 't> = exec::Matches<backends::DefaultExecutor<'r, 't>>;

--- a/src/bytesearch.rs
+++ b/src/bytesearch.rs
@@ -1,6 +1,8 @@
 use crate::insn::MAX_CHAR_SET_LENGTH;
-use std::fmt;
+use core::fmt;
 extern crate memchr;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 /// Facilities for searching bytes.
 pub trait ByteSearcher {
@@ -11,7 +13,7 @@ pub trait ByteSearcher {
 }
 
 /// Helper trait that describes matching against literal bytes.
-pub trait ByteSeq: ByteSearcher + std::fmt::Debug + Copy + Clone {
+pub trait ByteSeq: ByteSearcher + core::fmt::Debug + Copy + Clone {
     /// Number of bytes.
     const LENGTH: usize;
 

--- a/src/classicalbacktrack.rs
+++ b/src/classicalbacktrack.rs
@@ -14,7 +14,9 @@ use crate::scm;
 use crate::scm::SingleCharMatcher;
 use crate::types::{CaptureGroupID, GroupData, LoopData, LoopID, IP, MAX_CAPTURE_GROUPS};
 use crate::util::DebugCheckIndex;
-use std::ops::Range;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+use core::ops::Range;
 
 #[derive(Clone, Debug)]
 enum BacktrackInsn<Input: InputIndexer> {
@@ -366,13 +368,13 @@ impl<'a, Input: InputIndexer> MatchAttempter<'a, Input> {
         // Start with an "empty" backtrack stack.
         // TODO: consider using a stack-allocated array.
         let mut saved_bts = vec![BacktrackInsn::Exhausted];
-        std::mem::swap(&mut self.bts, &mut saved_bts);
+        core::mem::swap(&mut self.bts, &mut saved_bts);
 
         // Enter into the lookaround's instruction stream.
         let matched = self.try_at_pos(*input, ip, pos, Dir::new()).is_some();
 
         // Put back our bts.
-        std::mem::swap(&mut self.bts, &mut saved_bts);
+        core::mem::swap(&mut self.bts, &mut saved_bts);
 
         // If we are a positive lookahead that successfully matched, retain the
         // capture groups (but we need to set up backtracking). Otherwise restore

--- a/src/codepointset.rs
+++ b/src/codepointset.rs
@@ -1,6 +1,8 @@
 use crate::util::SliceHelp;
-use std::cmp::Ordering;
-use std::iter::once;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::iter::once;
 
 pub type CodePoint = u32;
 
@@ -59,7 +61,7 @@ impl Interval {
     }
 
     /// Return the interval of codepoints.
-    pub fn codepoints(self) -> std::ops::Range<u32> {
+    pub fn codepoints(self) -> core::ops::Range<u32> {
         debug_assert!(self.last + 1 > self.last, "Overflow");
         self.first..(self.last + 1)
     }
@@ -74,8 +76,8 @@ impl Interval {
 fn merge_intervals(x: Interval, y: &Interval) -> Interval {
     debug_assert!(x.mergeable(*y), "Ranges not mergeable");
     Interval {
-        first: std::cmp::min(x.first, y.first),
-        last: std::cmp::max(x.last, y.last),
+        first: core::cmp::min(x.first, y.first),
+        last: core::cmp::max(x.last, y.last),
     }
 }
 
@@ -150,7 +152,7 @@ impl CodePointSet {
     pub fn add_set(&mut self, mut rhs: CodePointSet) {
         // Prefer to add to the set with more intervals.
         if self.ivs.len() < rhs.ivs.len() {
-            std::mem::swap(self, &mut rhs);
+            core::mem::swap(self, &mut rhs);
         }
         for iv in rhs.intervals() {
             self.add(*iv)

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -7,7 +7,7 @@ pub struct Forward;
 #[derive(Debug, Copy, Clone)]
 pub struct Backward;
 
-pub trait Direction: std::fmt::Debug + Copy + Clone {
+pub trait Direction: core::fmt::Debug + Copy + Clone {
     const FORWARD: bool;
     fn new() -> Self;
 }

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -7,8 +7,11 @@ use crate::ir::Node;
 use crate::startpredicate;
 use crate::types::{BracketContents, CaptureGroupID, LoopID};
 use crate::unicode;
+use core::convert::TryInto;
+#[cfg(feature = "std")]
 use std::collections::HashMap;
-use std::convert::TryInto;
+#[cfg(not(feature = "std"))]
+use {alloc::vec::Vec, hashbrown::HashMap};
 
 /// \return an anchor instruction for a given IR anchor.
 fn make_anchor(anchor_type: ir::AnchorType) -> Insn {
@@ -94,7 +97,7 @@ impl Emitter {
                 if !*icase {
                     self.emit_insn(Insn::Char(c))
                 } else {
-                    std::debug_assert!(unicode::fold(c) == c, "Char should be folded");
+                    core::debug_assert!(unicode::fold(c) == c, "Char should be folded");
                     self.emit_insn(Insn::CharICase(c))
                 }
             }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -7,7 +7,7 @@ use crate::position::PositionType;
 /// A trait for finding the next match in a regex.
 /// This is broken out from Executor to avoid needing to thread lifetimes
 /// around.
-pub trait MatchProducer: std::fmt::Debug {
+pub trait MatchProducer: core::fmt::Debug {
     /// The position type of our indexer.
     type Position: PositionType;
 

--- a/src/indexing.rs
+++ b/src/indexing.rs
@@ -2,18 +2,18 @@ use crate::bytesearch;
 use crate::matchers;
 use crate::position::{DefPosition, PositionType};
 use crate::util::{is_utf8_continuation, utf8_w2, utf8_w3, utf8_w4};
-use std::convert::TryInto;
-use std::{ops, str};
+use core::convert::TryInto;
+use core::{ops, str};
 
 // A type which may be an Element.
 pub trait ElementType:
-    std::fmt::Debug
+    core::fmt::Debug
     + Copy
     + Clone
-    + std::cmp::Eq
-    + std::cmp::Ord
-    + std::convert::Into<u32>
-    + std::convert::TryFrom<u32>
+    + core::cmp::Eq
+    + core::cmp::Ord
+    + core::convert::Into<u32>
+    + core::convert::TryFrom<u32>
 {
     /// Return the length of ourself in bytes.
     fn bytelength(self) -> usize;
@@ -54,7 +54,7 @@ impl ElementType for u8 {
 }
 
 // A helper type that holds a string and allows indexing into it.
-pub trait InputIndexer: std::fmt::Debug + Copy + Clone
+pub trait InputIndexer: core::fmt::Debug + Copy + Clone
 where
     Self::CharProps: matchers::CharProperties<Element = Self::Element>,
 {
@@ -196,13 +196,13 @@ impl<'a> Utf8Input<'a> {
         self.debug_assert_boundary(range.start);
         self.debug_assert_boundary(range.end);
         if cfg!(feature = "prohibit-unsafe") {
-            &self.input[std::ops::Range {
+            &self.input[core::ops::Range {
                 start: self.pos_to_offset(range.start),
                 end: self.pos_to_offset(range.end),
             }]
         } else {
             unsafe {
-                self.input.get_unchecked(std::ops::Range {
+                self.input.get_unchecked(core::ops::Range {
                     start: self.pos_to_offset(range.start),
                     end: self.pos_to_offset(range.end),
                 })
@@ -241,13 +241,13 @@ impl<'a> InputIndexer for Utf8Input<'a> {
         debug_assert!(end >= start, "Slice start after end");
 
         #[cfg(any(feature = "index-positions", feature = "prohibit-unsafe"))]
-        let res = &self.contents()[std::ops::Range {
+        let res = &self.contents()[core::ops::Range {
             start: self.pos_to_offset(start),
             end: self.pos_to_offset(end),
         }];
 
         #[cfg(all(not(feature = "index-positions"), not(feature = "prohibit-unsafe")))]
-        let res = unsafe { std::slice::from_raw_parts(start.ptr(), end - start) };
+        let res = unsafe { core::slice::from_raw_parts(start.ptr(), end - start) };
 
         debug_assert!(res.len() <= self.bytelength() && res.len() == end - start);
         res
@@ -285,7 +285,7 @@ impl<'a> InputIndexer for Utf8Input<'a> {
             _ => rs_unreachable!("Invalid utf8 sequence length"),
         };
         *pos += len;
-        if let Some(c) = std::char::from_u32(codepoint) {
+        if let Some(c) = core::char::from_u32(codepoint) {
             Some(c)
         } else {
             rs_unreachable!("Should have decoded a valid char from utf8 sequence");
@@ -342,7 +342,7 @@ impl<'a> InputIndexer for Utf8Input<'a> {
             }
         }
         self.debug_assert_boundary(*pos);
-        if let Some(c) = std::char::from_u32(codepoint) {
+        if let Some(c) = core::char::from_u32(codepoint) {
             Some(c)
         } else {
             rs_unreachable!("Should have decoded a valid char from utf8 sequence");
@@ -511,13 +511,13 @@ impl<'a> InputIndexer for AsciiInput<'a> {
         self.debug_assert_valid_pos(end);
 
         #[cfg(any(feature = "index-positions", feature = "prohibit-unsafe"))]
-        let res = &self.contents()[std::ops::Range {
+        let res = &self.contents()[core::ops::Range {
             start: self.pos_to_offset(start),
             end: self.pos_to_offset(end),
         }];
 
         #[cfg(all(not(feature = "index-positions"), not(feature = "prohibit-unsafe")))]
-        let res = unsafe { std::slice::from_raw_parts(start.ptr(), end - start) };
+        let res = unsafe { core::slice::from_raw_parts(start.ptr(), end - start) };
 
         debug_assert!(res.len() <= self.bytelength() && res.len() == end - start);
         res
@@ -529,7 +529,7 @@ impl<'a> InputIndexer for AsciiInput<'a> {
         self.debug_assert_valid_pos(range.end);
         debug_assert!(range.end >= range.start);
         AsciiInput {
-            input: &self.input[std::ops::Range {
+            input: &self.input[core::ops::Range {
                 start: self.pos_to_offset(range.start),
                 end: self.pos_to_offset(range.end),
             }],

--- a/src/insn.rs
+++ b/src/insn.rs
@@ -1,6 +1,12 @@
 //! Bytecode instructions for a compiled regex
 
+#[cfg(feature = "std")]
 use std::collections::HashMap;
+#[cfg(not(feature = "std"))]
+use {
+    alloc::{string::String, vec::Vec},
+    hashbrown::HashMap,
+};
 
 use crate::api;
 use crate::bytesearch::{AsciiBitmap, ByteArraySet, ByteBitmap};

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -3,7 +3,9 @@
 use crate::api;
 use crate::types::{BracketContents, CaptureGroupID, CaptureGroupName};
 use crate::unicode::PropertyEscape;
-use std::fmt;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::ToString, vec::Vec};
+use core::fmt;
 
 #[derive(Debug, Copy, Clone)]
 pub enum AnchorType {
@@ -90,7 +92,7 @@ pub enum Node {
     Loop {
         loopee: Box<Node>,
         quant: Quantifier,
-        enclosed_groups: std::ops::Range<u16>,
+        enclosed_groups: core::ops::Range<u16>,
     },
 
     /// A loop whose body matches exactly one character.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,10 +109,15 @@ regress has a parser, intermediate representation, optimizer which acts on the I
 The major interpreter is the "classical backtracking" which uses an explicit backtracking stack, similar to JS implementations. There is also the "PikeVM" pseudo-toy backend which is mainly used for testing and verification.
 */
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(clippy::all)]
 #![allow(clippy::upper_case_acronyms, clippy::match_like_matches_macro)]
 // Clippy's manual_range_contains suggestion produces worse codegen.
 #![allow(clippy::manual_range_contains)]
+
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate alloc;
 
 pub use crate::api::*;
 

--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -66,7 +66,7 @@ impl CharProperties for ASCIICharProperties {
 pub fn backref<Input: InputIndexer, Dir: Direction>(
     input: &Input,
     dir: Dir,
-    orig_range: std::ops::Range<Input::Position>,
+    orig_range: core::ops::Range<Input::Position>,
     pos: &mut Input::Position,
 ) -> bool {
     cursor::subrange_eq(input, dir, pos, orig_range.start, orig_range.end)
@@ -75,7 +75,7 @@ pub fn backref<Input: InputIndexer, Dir: Direction>(
 pub fn backref_icase<Input: InputIndexer, Dir: Direction>(
     input: &Input,
     dir: Dir,
-    orig_range: std::ops::Range<Input::Position>,
+    orig_range: core::ops::Range<Input::Position>,
     pos: &mut Input::Position,
 ) -> bool {
     let ref_input = input.subinput(orig_range);

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -4,6 +4,8 @@ use crate::insn::{MAX_BYTE_SET_LENGTH, MAX_CHAR_SET_LENGTH};
 use crate::ir::*;
 use crate::types::BracketContents;
 use crate::unicode;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, vec::Vec};
 
 /// When unrolling a loop, the largest minimum count we will unroll.
 const LOOP_UNROLL_THRESHOLD: usize = 5;
@@ -187,7 +189,7 @@ fn decat(n: &mut Node, _w: &Walk) -> PassAction {
                 // we can return.
                 // Avoid copying nodes by switching them into owned vec.
                 let mut catted = Vec::new();
-                std::mem::swap(nodes, &mut catted);
+                core::mem::swap(nodes, &mut catted);
 
                 // Decat them.
                 let mut decatted = Vec::new();
@@ -269,7 +271,7 @@ fn unroll_loops(n: &mut Node, _w: &Walk) -> PassAction {
             if quant.max > 0 {
                 // Move the loop to the end of unrolled.
                 let mut loop_node = Node::Empty;
-                std::mem::swap(&mut loop_node, n);
+                core::mem::swap(&mut loop_node, n);
                 unrolled.push(loop_node);
             }
             *n = Node::Cat(unrolled);
@@ -300,7 +302,7 @@ fn promote_1char_loops(n: &mut Node, _w: &Walk) -> PassAction {
 
             // This feels hackish?
             let mut new_loopee = Box::new(Node::Empty);
-            std::mem::swap(&mut new_loopee, loopee);
+            core::mem::swap(&mut new_loopee, loopee);
 
             *n = Node::Loop1CharBody {
                 loopee: new_loopee,
@@ -358,7 +360,7 @@ fn form_literal_bytes(n: &mut Node, walk: &Walk) -> PassAction {
                             curr_bytes.append(prev_bytes);
                         } else {
                             prev_bytes.append(curr_bytes);
-                            std::mem::swap(prev_bytes, curr_bytes);
+                            core::mem::swap(prev_bytes, curr_bytes);
                         }
                         modified = true;
                     }

--- a/src/position.rs
+++ b/src/position.rs
@@ -1,11 +1,11 @@
-use std::cmp::Eq;
-use std::marker::PhantomData;
-use std::ops;
+use core::cmp::Eq;
+use core::marker::PhantomData;
+use core::ops;
 
 /// A trait which references a position in an input string.
 /// The intent is that this may be satisfied via indexes or pointers.
 /// Positions must be subtractable, producing usize; they also obey other "pointer arithmetic" ideas.
-pub trait PositionType: std::fmt::Debug + Copy + Clone + PartialEq + Eq + PartialOrd + Ord
+pub trait PositionType: core::fmt::Debug + Copy + Clone + PartialEq + Eq + PartialOrd + Ord
 where
     Self: ops::Add<usize, Output = Self>,
     Self: ops::Sub<usize, Output = Self>,
@@ -89,7 +89,7 @@ impl PositionType for IndexPosition<'_> {}
 /// This must use raw pointers because it must be capable of representing the one-past-the-end value.
 /// TODO: thread lifetimes through this.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct RefPosition<'a>(std::ptr::NonNull<u8>, PhantomData<&'a ()>);
+pub struct RefPosition<'a>(core::ptr::NonNull<u8>, PhantomData<&'a ()>);
 
 #[allow(dead_code)]
 impl RefPosition<'_> {
@@ -97,7 +97,7 @@ impl RefPosition<'_> {
     /// Good candidate for const-panics when stabilized.
     #[inline(always)]
     pub fn check_size() {
-        if std::mem::size_of::<Option<Self>>() > std::mem::size_of::<*const u8>() {
+        if core::mem::size_of::<Option<Self>>() > core::mem::size_of::<*const u8>() {
             panic!("Option<RefPosition> should be pointer sized")
         }
     }
@@ -115,9 +115,9 @@ impl RefPosition<'_> {
         // Annoyingly there's no *const NonNull.
         let mutp = ptr as *mut u8;
         let nonnullp = if cfg!(feature = "prohibit-unsafe") {
-            std::ptr::NonNull::new(mutp).expect("Pointer was null")
+            core::ptr::NonNull::new(mutp).expect("Pointer was null")
         } else {
-            unsafe { std::ptr::NonNull::new_unchecked(mutp) }
+            unsafe { core::ptr::NonNull::new_unchecked(mutp) }
         };
         Self(nonnullp, PhantomData)
     }

--- a/src/startpredicate.rs
+++ b/src/startpredicate.rs
@@ -4,8 +4,10 @@ use crate::insn::StartPredicate;
 use crate::ir;
 use crate::ir::Node;
 use crate::util::utf8_first_byte;
-use std::cmp;
-use std::convert::TryInto;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, vec::Vec};
+use core::cmp;
+use core::convert::TryInto;
 
 /// Support for quickly finding potential match locations.
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,8 @@
 use crate::codepointset::CodePointSet;
 use crate::position::PositionType;
-use std::ops;
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+use core::ops;
 
 /// A group index is u16.
 /// CaptureGroupID 0 corresponds to the first capture group.

--- a/src/unicode.rs
+++ b/src/unicode.rs
@@ -1,7 +1,9 @@
 use crate::codepointset::{CodePointSet, Interval};
 use crate::unicodetables::{self, FOLDS};
 use crate::util::SliceHelp;
-use std::cmp::Ordering;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+use core::cmp::Ordering;
 
 // CodePointRange packs a code point and a length together into a u32.
 // We currently do not need to store any information about code points in plane 16 (U+100000),
@@ -129,7 +131,7 @@ impl FoldRange {
 
     fn add_delta(&self, cu: u32) -> u32 {
         let cs = (cu as i32) + self.delta();
-        std::debug_assert!(0 <= cs && cs <= 0x10FFFF);
+        core::debug_assert!(0 <= cs && cs <= 0x10FFFF);
         cs as u32
     }
 
@@ -205,8 +207,8 @@ fn fold_interval(iv: Interval, recv: &mut CodePointSet) {
         // Find the (inclusive) range of our interval that this transform covers.
         // TODO: could walk by modulo amount.
         // TODO: optimize for cases when modulo is 1.
-        let first_trans = std::cmp::max(fr.first(), iv.first);
-        let last_trans = std::cmp::min(fr.last(), iv.last);
+        let first_trans = core::cmp::max(fr.first(), iv.first);
+        let last_trans = core::cmp::min(fr.last(), iv.last);
         for cu in first_trans..(last_trans + 1) {
             let cs = fr.apply(cu);
             if cs != cu {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,9 @@
 use crate::codepointset::CODE_POINT_MAX;
-use std::cmp::Ordering;
-use std::ops::{Index, IndexMut};
-use std::slice::SliceIndex;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::ops::{Index, IndexMut};
+use core::slice::SliceIndex;
 
 // A macro which expresses either checked or unchecked reachability, depending on prohibit-unsafe.
 macro_rules! rs_unreachable {
@@ -9,14 +11,14 @@ macro_rules! rs_unreachable {
         if cfg!(feature = "prohibit-unsafe") {
             unreachable!();
         } else {
-            unsafe { std::hint::unreachable_unchecked() }
+            unsafe { core::hint::unreachable_unchecked() }
         }
     }};
     ($msg:expr) => {
         if cfg!(feature = "prohibit-unsafe") {
             unreachable!($msg);
         } else {
-            unsafe { std::hint::unreachable_unchecked() }
+            unsafe { core::hint::unreachable_unchecked() }
         }
     };
 }
@@ -101,14 +103,14 @@ pub trait SliceHelp {
 
     /// Given that self is sorted according to f, returns the range of indexes
     /// where f indicates equal elements.
-    fn equal_range_by<'a, F>(&'a self, f: F) -> std::ops::Range<usize>
+    fn equal_range_by<'a, F>(&'a self, f: F) -> core::ops::Range<usize>
     where
         F: FnMut(&'a Self::Item) -> Ordering;
 }
 
 impl<T> SliceHelp for [T] {
     type Item = T;
-    fn equal_range_by<'a, F>(&'a self, mut f: F) -> std::ops::Range<usize>
+    fn equal_range_by<'a, F>(&'a self, mut f: F) -> core::ops::Range<usize>
     where
         F: FnMut(&'a Self::Item) -> Ordering,
     {
@@ -216,7 +218,7 @@ mod tests {
         ] {
             use super::{utf8_w2, utf8_w3, utf8_w4};
             let mut buff = [0; 4];
-            let s = std::char::from_u32(cp).unwrap().encode_utf8(&mut buff);
+            let s = core::char::from_u32(cp).unwrap().encode_utf8(&mut buff);
             let bytes = s.as_bytes();
             assert_eq!(bytes[0], super::utf8_first_byte(cp));
 


### PR DESCRIPTION
It's great to support `no_std`

1. Rename `std` to `core` and `alloc`.
2. use `hashbrown` replace `std`