### PR TITLE
Introduce new API to parse regex from Unicode codepoints iterator

### DIFF
--- a/regress-tool/src/regress-tool.rs
+++ b/regress-tool/src/regress-tool.rs
@@ -93,7 +93,7 @@ fn main() -> Result<(), Error> {
     let args = Opt::from_args();
 
     let flags = args.flags.unwrap_or_default();
-    let mut ire = backends::try_parse(&args.pattern, flags)?;
+    let mut ire = backends::try_parse(args.pattern.chars().map(u32::from), flags)?;
     if args.dump_phases || args.dump_unoptimized_ir {
         println!("Unoptimized IR:\n{}", ire);
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -79,6 +79,14 @@ where
     }
 }
 
+// Helper function for matching u32s against chars.
+// It would be pleasant if you could pattern-match u32s against chars, but Rust does not allow this.
+// Convert a u32 to a char, except if the conversion fails, return the largest char.
+// Be careful to not use the result of this conversion except to pattern match against literals.
+pub fn to_char_sat(c: u32) -> char {
+    char::from_u32(c).unwrap_or(core::char::MAX)
+}
+
 /// \return the first byte of a UTF-8 encoded code point.
 /// We do not use char because we don't want to deal with failing on surrogates.
 pub fn utf8_first_byte(cp: u32) -> u8 {


### PR DESCRIPTION
This PR follows from #45, and partially solves #43.

This design should be backwards compatible with all users of `regress`, since it doesn't modify existing APIs. (Well, almost. `backends::try_parse` exists but it's doc hidden, and I had to slightly modify it to accept `u32` iterators)

The main change is the addition of `Regex::from_unicode`, which allows any `u32` iterator (a Unicode codepoints iterator) as a parseable pattern. 

The next step is to implement the required functionality in `Executor` to find matches in `UTF-16` strings, but that's a bit more work and would belong on a separate PR.