### PR TITLE
parse "unbalanced" right square bracket as a literal character

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -39,13 +39,16 @@ pub struct Flags {
 
     /// If set, disable regex IR passes.
     pub no_opt: bool,
+
+    /// If set, the regex is interpreted as a Unicode regex.
+    /// Equivalent to the 'u' flag in JavaScript.
+    pub unicode: bool,
 }
 
 impl Flags {
     /// Construct a Flags from a Unicode codepoints iterator, using JavaScript field names.
-    /// 'i' means to ignore case, 'm' means multiline.
+    /// 'i' means to ignore case, 'm' means multiline, 'u' means unicode.
     /// Note the 'g' flag implies a stateful regex and is not supported.
-    /// Note the 'u' flag currently only controls if invalid backreferences should throw a syntax error.
     /// Other flags are not implemented and are ignored.
     #[inline]
     pub fn new<T: Iterator<Item = u32>>(chars: T) -> Self {
@@ -60,6 +63,9 @@ impl Flags {
                 }
                 's' => {
                     result.dot_all = true;
+                }
+                'u' => {
+                    result.unicode = true;
                 }
                 _ => {
                     // Silently skip unsupported flags.
@@ -87,6 +93,12 @@ impl fmt::Display for Flags {
         }
         if self.icase {
             f.write_str("i")?;
+        }
+        if self.dot_all {
+            f.write_str("s")?;
+        }
+        if self.unicode {
+            f.write_str("u")?;
         }
         Ok(())
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -340,7 +340,7 @@ where
                     result.push(self.consume_bracket()?);
                 }
 
-                ']' => {
+                ']' if self.flags.unicode => {
                     return error("Unbalanced bracket");
                 }
 

--- a/tests/syntax_error_tests.rs
+++ b/tests/syntax_error_tests.rs
@@ -1,5 +1,5 @@
 fn test_1_error(pattern: &str, expected_err: &str) {
-    let res = regress::Regex::new(pattern);
+    let res = regress::Regex::with_flags(pattern, "u");
     assert!(res.is_err(), "Pattern should not have parsed: {}", pattern);
 
     let err = res.err().unwrap().text;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -303,6 +303,11 @@ fn run_misc_tests_tc(tc: TestConfig) {
         vec![Some("baaabaac"), Some("ba"), None, Some("abaac")]
     );
     tc.compilef(r"\0", "").match1f("abc\0def").test_eq("\0");
+
+    assert_eq!(
+        tc.compilef(r";'()([/,-6,/])()]", "").match1_vec(";'/]"),
+        vec![Some(";'/]"), Some(""), Some("/"), Some("")]
+    );
 }
 
 #[test]


### PR DESCRIPTION
I ran into a related issue in boa_engine: https://github.com/boa-dev/boa/issues/2325

I have no idea how to read the ECMAScript documentation, but the introduced behavior is the behavior of regex engines in V8 and SpiderMonkey.

while this commit doesn't seem to fix it in Boa, I believe this change is needed anyway.