### PR TITLE
Allow all punctuations to be escaped

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -719,12 +719,14 @@ where
             '^' | '$' | '\\' | '.' | '*' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '|'
             | '/' => Ok(self.consume(c)),
 
-            // TODO: currently we permit alphabetic characters in IdentityEscape to help some PCRE
+            // TODO: currently we reject numeric characters in IdentityEscape to help some PCRE
             // tests pass.
             // Specifically a regex of the form [\p{Nd}]: in non-Unicode mode this is not a
             // character property test and is expected to parse as just a bracket where \p is
             // IdentityEscaped to p.
-            c if c.is_ascii_alphabetic() => Ok(self.consume(c)),
+            c if (!self.flags.unicode && !c.is_ascii_digit()) || c.is_ascii_alphabetic() => {
+                Ok(self.consume(c))
+            }
 
             _ => error("Invalid character escape"),
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -311,6 +311,11 @@ fn run_nonunicode_tests() {
 }
 
 fn run_nonunicode_test_tc(tc: TestConfig) {
+    // escaping unrecognised chars
+    tc.compilef(r"\ ", "").match1f(r" ").test_eq(r" ");
+    tc.compilef(r"\ a", "").match1f(r" a").test_eq(r" a");
+    tc.compilef(r"a\ ", "").match1f(r"a ").test_eq(r"a ");
+
     // no unbalanced bracket ']'
     tc.compilef(r"a]", "").match1f(r"a]").test_eq(r"a]");
     tc.compilef(r"]a", "").match1f(r"]a").test_eq(r"]a");


### PR DESCRIPTION
Previously, regex's like `/\-/`, or `/\!/` would fail to compile. In javascript (and other ecmascript based languages) these regex's are allowed, so they should be allowed in this crate as well.

For more info see https://github.com/ruffle-rs/ruffle/issues/9859