### PR TITLE
[unicode] fail parsing invalid quantifiers

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -346,9 +346,10 @@ where
 
                 _ => {
                     // It's an error if this parses successfully as a quantifier.
+                    // It's also an error if this is an invalid quantifier (with 'u' flag).
                     // Note this covers *, +, ? as well.
                     let saved = self.input.clone();
-                    if let Ok(Some(_)) = self.try_consume_quantifier() {
+                    if self.try_consume_quantifier()?.is_some() {
                         return error("Nothing to repeat");
                     }
                     self.input = saved;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -338,6 +338,23 @@ fn run_nonunicode_test_tc(tc: TestConfig) {
 }
 
 #[test]
+fn run_unicode_tests() {
+    // escaping unrecognised chars
+    test_parse_fails_flags(r"\ ", "u");
+    test_parse_fails_flags(r"\ a", "u");
+    test_parse_fails_flags(r"a\ ", "u");
+
+    // no unbalanced bracket ']'
+    test_parse_fails_flags(r"a]", "u");
+    test_parse_fails_flags(r"]a", "u");
+    test_parse_fails_flags(r"]", "u");
+
+    // no invalid quantifier ('{')
+    test_parse_fails_flags(r"a{", "u");
+    test_parse_fails_flags(r"{a", "u");
+}
+
+#[test]
 fn run_regexp_capture_test() {
     test_with_configs(run_regexp_capture_test_tc)
 }


### PR DESCRIPTION
stop ignoring errors from trying to parse invalid quantifiers