### PR TITLE
Implement valid character sets in Annex-B

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -82,6 +82,7 @@ impl TestCompiledRegex {
     }
 
     /// Match against a string, returning the first formatted match.
+    #[track_caller]
     pub fn match1f(&self, input: &str) -> String {
         match self.find(input) {
             Some(m) => format_match(&m, input),
@@ -116,11 +117,13 @@ impl TestCompiledRegex {
     }
 
     /// Test that matching against \p input fails.
+    #[track_caller]
     pub fn test_fails(&self, input: &str) {
         assert!(self.find(input).is_none(), "Should not have matched")
     }
 
     /// Test that matching against \p input succeeds.
+    #[track_caller]
     pub fn test_succeeds(&self, input: &str) {
         assert!(self.find(input).is_some(), "Should have matched")
     }
@@ -184,6 +187,7 @@ impl TestConfig {
     }
 
     /// Compile a pattern to a regex, with given flags.
+    #[track_caller]
     pub fn compilef(&self, pattern: &str, flags_str: &str) -> TestCompiledRegex {
         let mut flags = regress::Flags::from(flags_str);
         flags.no_opt = !self.optimize;
@@ -204,6 +208,7 @@ impl TestConfig {
 
     /// Test that \p pattern and \p flags successfully parses, and matches
     /// \p input.
+    #[track_caller]
     pub fn test_match_succeeds(&self, pattern: &str, flags_str: &str, input: &str) {
         let cr = self.compilef(pattern, flags_str);
         cr.test_succeeds(input)

--- a/tests/syntax_error_tests.rs
+++ b/tests/syntax_error_tests.rs
@@ -1,3 +1,4 @@
+#[track_caller]
 fn test_1_error(pattern: &str, expected_err: &str) {
     let res = regress::Regex::with_flags(pattern, "u");
     assert!(res.is_err(), "Pattern should not have parsed: {}", pattern);
@@ -39,8 +40,13 @@ fn test_syntax_errors() {
     test_1_error(r"(?!", "Unbalanced parenthesis");
     test_1_error(r"abc)", "Unbalanced parenthesis");
 
-    test_1_error(r"[z-a]", "Invalid character range");
-    test_1_error(r"[\d-z]", "Invalid character range");
+    test_1_error(
+        r"[z-a]",
+        "Range values reversed, start char code is greater than end char code.",
+    );
+
+    // In unicode mode this is not allowed.
+    test_1_error(r"[a-\s]", "Invalid character range");
 
     test_1_error("\\", "Incomplete escape");
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1451,3 +1451,27 @@ fn unicode_escape_id_continue_tc(tc: TestConfig) {
         }
     }
 }
+
+#[test]
+fn test_valid_character_sets_in_annex_b() {
+    test_with_configs(test_valid_character_sets_in_annex_b_tc)
+}
+
+fn test_valid_character_sets_in_annex_b_tc(tc: TestConfig) {
+    // From: https://github.com/boa-dev/boa/issues/2794
+    let regexp = r"[a-\s]";
+    tc.test_match_succeeds(regexp, "", "a");
+    tc.test_match_succeeds(regexp, "", "-");
+    tc.test_match_succeeds(regexp, "", " ");
+    tc.test_match_fails(regexp, "", "s");
+    tc.test_match_fails(regexp, "", "$");
+
+    let regexp = r"[\d-z]";
+    tc.test_match_succeeds(regexp, "", "z");
+    tc.test_match_succeeds(regexp, "", "1");
+    tc.test_match_succeeds(regexp, "", "7");
+    tc.test_match_succeeds(regexp, "", "9");
+    tc.test_match_fails(regexp, "", "a");
+    tc.test_match_fails(regexp, "", "f");
+    tc.test_match_fails(regexp, "", " ");
+}


### PR DESCRIPTION
~~This adds the `"annex-b"` which enables [EcmaScript's Annex-B RegExp syntax](https://tc39.es/ecma262/#sec-regular-expressions-patterns).~~

Regexes like `[a-\s]` and `[--\d]` are allowed in Annex-b and are not treated like a range, but with mach any char rule. This only applies in non-unicode mode.
