### PR TITLE
Add `U+00A0` to whitespaces

### DIFF
--- a/src/charclasses.rs
+++ b/src/charclasses.rs
@@ -26,15 +26,53 @@ pub const WORD_CHARS: [Interval; 4] = [r('0', '9'), r('A', 'Z'), r1('_'), r('a',
 /// ES9 21.2.2.12
 pub const DIGITS: [Interval; 1] = [r('0', '9')];
 
-/// ES9 11.2
-pub const WHITESPACE: [Interval; 8] = [
+/// [`ES13 12.2 White Space`][spec]
+///
+/// [spec]: https://262.ecma-international.org/13.0/#prod-WhiteSpace
+pub const WHITESPACE: [Interval; 9] = [
+    // U+0009 - Character Tabulation - <TAB>
+    // U+000B - Line Tabulation      - <VT>
+    // U+000C - Form Feed (FF)       - <FF>
     r('\u{0009}', '\u{000C}'),
+    // From unicode “Space_Separator” (`Zs`) category:
+    //
+    // U+0020 - Space - <SP>
     r1('\u{0020}'),
+    // From unicode “Space_Separator” (`Zs`) category:
+    //
+    // U+00A0 - No-Break Space - <NBSP>
+    r1('\u{00A0}'),
+    // From unicode “Space_Separator” (`Zs`) category:
+    //
+    // U+1680 - Ogham Space Mark
     r1('\u{1680}'),
+    // From unicode “Space_Separator” (`Zs`) category:
+    //
+    // U+2000 - En Quad
+    // U+2001 - Em Quad
+    // U+2002 - En Space
+    // U+2003 - Em Space
+    // U+2004 - Three-Per-Em Space
+    // U+2005 - Four-Per-Em Space
+    // U+2006 - Six-Per-Em Space
+    // U+2007 - Figure Space
+    // U+2008 - Punctuation Space
+    // U+2009 - Thin Space
+    // U+200A - Hair Space
     r('\u{2000}', '\u{200A}'),
+    // From unicode “Space_Separator” (`Zs`) category:
+    //
+    // U+202F - Narrow No-Break Space - <NNBSP>
     r1('\u{202F}'),
+    // From unicode “Space_Separator” (`Zs`) category:
+    //
+    // U+205F - Medium Mathematical Space - <MMSP>
     r1('\u{205F}'),
+    // From unicode “Space_Separator” (`Zs`) category:
+    //
+    // U+3000 - Ideographic Space
     r1('\u{3000}'),
+    // U+FEFF - ZERO WIDTH NO-BREAK SPACE - <ZWNBSP>
     r1('\u{FEFF}'),
 ];
 


### PR DESCRIPTION
This PR adds `U+00A0` to whitespaces which was failing a [test262](https://github.com/tc39/test262/blob/72c0c5e16350a76bd41f7a1ceb7702588a2a39c6/test/built-ins/RegExp/character-class-escape-non-whitespace.js#L25) test

Also updated the spec and added link with comments