### PR TITLE
Disallow invalid quantifier after lookbehinds

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -287,6 +287,7 @@ where
                         })?);
                     } else if self.try_consume_str("(?<=") {
                         // Positive lookbehind.
+                        quantifier_allowed = false;
                         self.has_lookbehind = true;
                         result.push(self.consume_lookaround_assertion(LookaroundParams {
                             negate: false,
@@ -294,6 +295,7 @@ where
                         })?);
                     } else if self.try_consume_str("(?<!") {
                         // Negative lookbehind.
+                        quantifier_allowed = false;
                         self.has_lookbehind = true;
                         result.push(self.consume_lookaround_assertion(LookaroundParams {
                             negate: true,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -135,7 +135,19 @@ fn test_lookbehinds_tc(tc: TestConfig) {
 
 #[test]
 fn test_lookbehinds() {
-    test_with_configs(test_lookbehinds_tc)
+    test_with_configs(test_lookbehinds_tc);
+
+    // From 262 test/language/literals/regexp/invalid-range-negative-lookbehind.js
+    test_parse_fails(".(?<!.){2,3}");
+
+    // From 262 test/language/literals/regexp/invalid-range-lookbehind.js
+    test_parse_fails(".(?<=.){2,3}");
+
+    // From 262 test/language/literals/regexp/invalid-optional-negative-lookbehind.js
+    test_parse_fails(".(?<!.)?");
+
+    // From 262 test/language/literals/regexp/invalid-optional-lookbehind.js
+    test_parse_fails(".(?<=.)?");
 }
 
 #[test]


### PR DESCRIPTION
This PR disallows invalid quantifiers after lookbehinds.

It also adds relevant tests from the 262 suite.