### PR TITLE
Require \ for unicode-escapes in named captures

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -932,7 +932,7 @@ where
         let mut group_name = String::new();
 
         if let Some(mut c) = self.next().and_then(char::from_u32) {
-            if self.try_consume('u') {
+            if c == '\\' && self.try_consume('u') {
                 if let Some(escaped) = self.try_escape_unicode_sequence().and_then(char::from_u32) {
                     c = escaped;
                 } else {
@@ -954,7 +954,7 @@ where
 
         loop {
             if let Some(mut c) = self.next().and_then(char::from_u32) {
-                if self.try_consume('u') {
+                if c == '\\' && self.try_consume('u') {
                     if let Some(escaped) =
                         self.try_escape_unicode_sequence().and_then(char::from_u32)
                     {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1167,6 +1167,10 @@ fn run_regexp_named_capture_groups_tc(tc: TestConfig) {
     tc.compilef(r#"(?<a>a)(?<b>b)\k<a>"#, "").match1_named_group("aba", "a").test_eq("a");
     tc.compilef(r#"(?<a>a)(?<b>b)\k<a>"#, "").match1_named_group("aba", "b").test_eq("b");
 
+    // regression test for
+    // https://github.com/ridiculousfish/regress/issues/41
+    tc.compilef(r#"(?<au>.)"#, "").match1_named_group("a", "au").test_eq("a");
+
     // Make sure that escapes are parsed correctly in the fast capture group parser.
     // This pattern should fail in unicode mode, because there is a backreference without a capture group.
     // If the `\]` is not handled correctly in the parser, the following `(.)` may be parsed as a capture group.


### PR DESCRIPTION
This resolves #41

Rather than only looking for `'u'`, look for something ever so slightly more strict: `"\\u"`.

This passes the existing tests and a very simple additional test which reproduces the issue from #41.

---

Minor caveat: I'm not an experienced hand at Rust. If I need to do more sophisticated work here, I am very willing to try my best but might not have the skills for it yet. :sweat_smile: 