### PR TITLE
Correct first-byte computation for interval

### DIFF
--- a/src/bytesearch.rs
+++ b/src/bytesearch.rs
@@ -218,7 +218,7 @@ impl ByteSet for AsciiBitmap {
 }
 
 /// A bitmap covering all bytes.
-#[derive(Default, Copy, Clone)]
+#[derive(Default, Copy, Clone, PartialEq, Eq)]
 #[repr(align(4))]
 pub struct ByteBitmap([u16; 16]);
 

--- a/src/unicode.rs
+++ b/src/unicode.rs
@@ -364,7 +364,7 @@ mod tests {
         for c in 0..=0x10FFFF {
             let fc = fold(c);
             if fc != c {
-                unfold_map.entry(fc).or_insert_with(Vec::new).push(c);
+                unfold_map.entry(fc).or_default().push(c);
             }
         }
 


### PR DESCRIPTION
When computing a predicate to match the first byte, we incorrectly assumed that the set of first bytes of a closed interval (in UTF8) are contiguous. But of course this is false. Reimplement this algorithm and add tests.

Fixes #73