### PR TITLE
Correctly reject characters in Atom PatternCharacter

### DIFF
--- a/tests/syntax_error_tests.rs
+++ b/tests/syntax_error_tests.rs
@@ -27,13 +27,13 @@ fn test_excessive_capture_groups() {
 
 #[test]
 fn test_syntax_errors() {
-    test_1_error(r"*", "Nothing to repeat");
-    test_1_error(r"x**", "Nothing to repeat");
-    test_1_error(r"?", "Nothing to repeat");
-    test_1_error(r"{3,5}", "Nothing to repeat");
+    test_1_error(r"*", "Invalid atom character");
+    test_1_error(r"x**", "Invalid atom character");
+    test_1_error(r"?", "Invalid atom character");
+    test_1_error(r"{3,5}", "Invalid atom character");
     test_1_error(r"x{5,3}", "Invalid quantifier");
 
-    test_1_error(r"]", "Unbalanced bracket");
+    test_1_error(r"]", "Invalid atom character");
     test_1_error(r"[abc", "Unbalanced bracket");
 
     test_1_error(r"(", "Unbalanced parenthesis");

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -369,6 +369,25 @@ fn run_unicode_tests() {
     test_parse_fails_flags(r"{a", "u");
 }
 
+/// 262 test/built-ins/RegExp/unicode_restricted_brackets.js
+#[test]
+fn run_unicode_restricted_brackets() {
+    test_parse_fails_flags(r"(", "u");
+    test_parse_fails_flags(r")", "u");
+    test_parse_fails_flags(r"[", "u");
+    test_parse_fails_flags(r"]", "u");
+    test_parse_fails_flags(r"{", "u");
+    test_parse_fails_flags(r"}", "u");
+
+    // Tests without the 'u' flag.
+    test_parse_fails(r"(");
+    test_parse_fails(r")");
+    test_parse_fails(r"[");
+    test_with_configs(|tc| tc.compile(r"]").match1f(r"]").test_eq(r"]"));
+    test_with_configs(|tc| tc.compile(r"{").match1f(r"{").test_eq(r"{"));
+    test_with_configs(|tc| tc.compile(r"}").match1f(r"}").test_eq(r"}"));
+}
+
 #[test]
 fn run_regexp_capture_test() {
     test_with_configs(run_regexp_capture_test_tc)


### PR DESCRIPTION
This fixes and cleans up some of the logic for parsing and detecting invalid characters in `Atom`s. I also added a relevant 262 test that is fixed by this.