### PR TITLE
Fix invalid quantifier loop

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -249,7 +249,7 @@ where
         let mut result: Vec<ir::Node> = Vec::new();
         loop {
             let start_group = self.group_count;
-            let start_offset = result.len();
+            let mut start_offset = result.len();
             let mut quantifier_allowed = true;
 
             let nc = self.peek();
@@ -304,6 +304,7 @@ where
                                     icase: self.flags.icase,
                                 });
                             } else {
+                                start_offset += 1;
                                 result.push(ir::Node::Char {
                                     c: u32::from('\\'),
                                     icase: self.flags.icase,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1582,3 +1582,12 @@ fn test_high_folds_tc(tc: TestConfig) {
     tc.test_match_fails(r"\u{1BD}", "", "\u{1BE}");
     tc.test_match_fails(r"\u{1BD}", "i", "\u{1BE}");
 }
+
+#[test]
+fn test_invalid_quantifier_loop() {
+    test_with_configs(test_invalid_quantifier_loop_tc)
+}
+
+fn test_invalid_quantifier_loop_tc(tc: TestConfig) {
+    tc.test_match_fails(r#"\c*"#, "", "\n");
+}


### PR DESCRIPTION
This fixes an invalid quantifier loop. The caused was an invalid loop start offset when two `Node`s where pushed before the quantifier.