### PR TITLE
Prepare the v0.8.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regress"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["ridiculousfish <corydoras@ridiculousfish.com>"]
 description = "A regular expression engine targeting EcmaScript syntax"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
@ridiculousfish With the latest PRs merged, regress now passes all test262 tests with the following exceptions:

- Tests with the `regexp-v-flag` proposal flag. This proposal is merged into the spec and I'm looking to implement it next.
- Tests with the `regexp-duplicate-named-groups` proposal flag. This proposal is in stage 3.
- Tests with the `legacy-regexp` proposal flag. This proposal is in stage 3.
- One test that depends on unicode 15.1 tables. Currently the test262 tests are divided between unicode 15.0 and 15.1.

I think this is a good point to publish a release :)