### PR TITLE
add documentation for feature `utf16`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,11 @@ fancy-regex wraps the regex crate and extends it with PCRE-style syntactic featu
 regress has a parser, intermediate representation, optimizer which acts on the IR, bytecode emitter, and two bytecode interpreters, referred to as "backends".
 
 The major interpreter is the "classical backtracking" which uses an explicit backtracking stack, similar to JS implementations. There is also the "PikeVM" pseudo-toy backend which is mainly used for testing and verification.
+
+# Crate features
+
+- **utf16**. When enabled, additional APIs are made available that allow matching text formatted in UTF-16 and UCS-2 (`&[u16]`) without going through a conversion to and from UTF-8 (`&str`) first. This is particularly useful when interacting with and/or (re)implementing existing systems that use those encodings, such as JavaScript, Windows, and the JVM.
+
 */
 
 #![cfg_attr(not(feature = "std"), no_std)]


### PR DESCRIPTION
I've been looking for a regex impl for my toy JavaScript implementation ([mcjs](https://github.com/sebastiano-barrera/mcjs/)), and I thought `regress` sounded good but still insufficient due to the lack of support for searching on UTF-16 strings.

Turns out, `regress` _does_ do exactly what I need! It's just nowhere to be found in the [crate documentation](https://docs.rs/regress) (at least not without following the 'Feature flags' link, which I had no reason to, I think). I only found this out by looking at what [boa does](https://github.com/boa-dev/boa/blob/109dd3d395859fcf0d8ecdc01b146b517437716e/core/engine/src/builtins/regexp/mod.rs#L976) for its own RegExp implementation.

So, I hope this little extra paragraph will be useful for the next one who walks my path.

Let me know if you'd like me to change the format or rephrase the text.