### PR TITLE
Named captures to return their names in-order

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -144,7 +144,6 @@ jobs:
       - uses: actions-rs/cargo@v1.0.3
         with:
           command: clippy
-          args: -- --verbose
 
   doc:
     name: Documentation check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regress"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["ridiculousfish <corydoras@ridiculousfish.com>"]
 description = "A regular expression engine targeting EcmaScript syntax"
 license = "MIT OR Apache-2.0"

--- a/src/classicalbacktrack.rs
+++ b/src/classicalbacktrack.rs
@@ -929,7 +929,7 @@ impl<'r, Input: InputIndexer> BacktrackExecutor<'r, Input> {
         Match {
             range: self.input.pos_to_offset(start)..self.input.pos_to_offset(end),
             captures,
-            named_captures: self.matcher.re.named_group_indices.clone(),
+            group_names: self.matcher.re.group_names.clone(),
         }
     }
 

--- a/src/insn.rs
+++ b/src/insn.rs
@@ -1,7 +1,5 @@
 //! Bytecode instructions for a compiled regex
 
-#[cfg(feature = "std")]
-use std::collections::HashMap;
 #[cfg(not(feature = "std"))]
 use {
     alloc::{string::String, vec::Vec},
@@ -180,11 +178,27 @@ pub enum StartPredicate {
 
 #[derive(Debug, Clone)]
 pub struct CompiledRegex {
+    // Sequence of instructions.
     pub insns: Vec<Insn>,
+
+    // The bracket contents, indexed by the value of the `Bracket` instruction.
     pub brackets: Vec<BracketContents>,
+
+    // Predicate to rapidly find the first potential match.
     pub start_pred: StartPredicate,
+
+    // Number of loops, used to populate loop data.
     pub loops: u32,
+
+    // Number of capture groups, used to populate capture group data.
     pub groups: u32,
-    pub named_group_indices: HashMap<String, u16>,
+
+    // A list of capture group names. This is either:
+    //   - Empty, if there were no named capture groups.
+    //   - A list of names with length `groups`, corresponding to the capture
+    //     group names in order. Groups without names have an empty string.
+    pub group_names: Box<[Box<str>]>,
+
+    // Flags controlling matching.
     pub flags: api::Flags,
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1250,7 +1250,7 @@ where
                 self.consume('+');
                 Ok(Some(ir::Quantifier {
                     min: 1,
-                    max: core::usize::MAX,
+                    max: usize::MAX,
                     greedy: true,
                 }))
             }
@@ -1258,7 +1258,7 @@ where
                 self.consume('*');
                 Ok(Some(ir::Quantifier {
                     min: 0,
-                    max: core::usize::MAX,
+                    max: usize::MAX,
                     greedy: true,
                 }))
             }
@@ -1306,7 +1306,7 @@ where
                 quant.max = max;
             } else {
                 // Like {3,}
-                quant.max = usize::max_value();
+                quant.max = usize::MAX;
             }
         } else {
             // Like {3}.

--- a/src/pikevm.rs
+++ b/src/pikevm.rs
@@ -14,14 +14,9 @@ use crate::scm;
 use crate::scm::SingleCharMatcher;
 use crate::types::{GroupData, LoopData};
 use crate::util::DebugCheckIndex;
-use core::ops::Range;
-#[cfg(feature = "std")]
-use std::collections::HashMap;
 #[cfg(not(feature = "std"))]
-use {
-    alloc::{string::String, vec::Vec},
-    hashbrown::HashMap,
-};
+use alloc::{string::String, vec::Vec};
+use core::ops::Range;
 
 #[derive(Debug, Clone)]
 struct State<Position: PositionType> {
@@ -325,7 +320,7 @@ fn successful_match<Input: InputIndexer>(
     input: Input,
     start: Input::Position,
     state: &State<Input::Position>,
-    named_captures: HashMap<String, u16>,
+    group_names: Box<[Box<str>]>,
 ) -> Match {
     let group_to_offset = |mr: &GroupData<Input::Position>| -> Option<Range<usize>> {
         mr.as_range().map(|r| Range {
@@ -337,7 +332,7 @@ fn successful_match<Input: InputIndexer>(
     Match {
         range: input.pos_to_offset(start)..input.pos_to_offset(state.pos),
         captures,
-        named_captures,
+        group_names,
     }
 }
 
@@ -449,7 +444,7 @@ impl<'a, Input: InputIndexer> exec::MatchProducer for PikeVMExecutor<'a, Input> 
                     self.input,
                     start,
                     &state,
-                    re.named_group_indices.clone(),
+                    re.group_names.clone(),
                 ));
             }
             match self.input.next_right_pos(start) {


### PR DESCRIPTION
Prior to this commit, the Match::named_groups() function would return names in an arbitrary order, because they were stored in a hash table. Switch to returning them in the original specification order from the pattern. This allows implementing the JS engine semantics where the object key order matches that from the pattern.

Fixes #96