### PR TITLE
Add `ExactSizeIterator` for groups

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -266,6 +266,12 @@ impl Iterator for Groups<'_> {
     }
 }
 
+impl<'m> ExactSizeIterator for Groups<'m> {
+    fn len(&self) -> usize {
+        self.max.saturating_sub(self.i)
+    }
+}
+
 /// An iterator over the named capture groups of a [`Match`]
 ///
 /// This struct is created by the [`named_groups`] method on [`Match`].

--- a/src/api.rs
+++ b/src/api.rs
@@ -310,6 +310,16 @@ impl<'m> Iterator for NamedGroups<'m> {
     }
 }
 
+impl<'m> ExactSizeIterator for NamedGroups<'m> {
+    fn len(&self) -> usize {
+        self.mat.captures[self.next_group_name_idx..]
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| !self.mat.group_names[*idx].is_empty())
+            .count()
+    }
+}
+
 /// A Regex is the compiled version of a pattern.
 #[derive(Debug, Clone)]
 pub struct Regex {


### PR DESCRIPTION
Adds two new implementations of [ExactSizeIterator](https://doc.rust-lang.org/stable/std/iter/trait.ExactSizeIterator.html) for `Groups` and `NamedGroups`

I think it is correct? Should I add tests somewhere?