### PR TITLE
Update CI workflow to include macOS in job matrices

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,10 @@ jobs:
 
   test-nightly:
     name: Test (Nightly)
-    runs-on: [ubuntu-latest, windows-latest, macos-latest]
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly


### PR DESCRIPTION
rm rustfmt because autofix has it.
