### PR TITLE
Update comparison to fancy-regex in documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ to the architecture: regex uses finite automata while regress uses "classical ba
 
 # Comparison to fancy-regex crate
 
-fancy-regex wraps the regex crate and extends it with PCRE-style syntactic features. regress has more complete support for these features: backreferences may be case-insensitive, and lookbehinds may be arbitrary-width.
+fancy-regex wraps the regex crate and extends it with PCRE-style syntactic features. regress has more complete support for these features: lookbehinds may be arbitrary-width.
 
 # Architecture
 


### PR DESCRIPTION
fancy-regex has supported case insensitive backreferences since [v0.15.0](https://github.com/fancy-regex/fancy-regex/releases/tag/0.15.0) :)

also, nice to see some friendly competition in this space, I wonder if we can each learn anything from the other engine's approach to mutually benefit :slightly_smiling_face: 
Wishing you best of luck with your great project!