### PR TITLE
fix typo in `Flags::dot_all` docs

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -41,7 +41,7 @@ pub struct Flags {
     pub multiline: bool,
 
     /// If set, . matches at line separators as well as any other character.
-    /// Equivalent to the 'm' flag in JavaScript.
+    /// Equivalent to the 's' flag in JavaScript.
     pub dot_all: bool,
 
     /// If set, disable regex IR passes.


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll