### PR TITLE
perf: Avoid allocation for no-match regex replacements

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -576,11 +576,7 @@ impl Regex {
         let mut result = String::with_capacity(text.len());
         let mut last_end = 0;
 
-        result.push_str(&text[last_end..first_match.start()]);
-        self.expand_replacement(&first_match, text, replacement, &mut result);
-        last_end = first_match.end();
-
-        for m in matches {
+        for m in core::iter::once(first_match).chain(matches) {
             result.push_str(&text[last_end..m.start()]);
             self.expand_replacement(&m, text, replacement, &mut result);
             last_end = m.end();
@@ -658,11 +654,7 @@ impl Regex {
         let mut result = String::with_capacity(text.len());
         let mut last_end = 0;
 
-        result.push_str(&text[last_end..first_match.start()]);
-        result.push_str(&replacement(&first_match));
-        last_end = first_match.end();
-
-        for m in matches {
+        for m in core::iter::once(first_match).chain(matches) {
             result.push_str(&text[last_end..m.start()]);
             result.push_str(&replacement(&m));
             last_end = m.end();

--- a/src/api.rs
+++ b/src/api.rs
@@ -576,7 +576,11 @@ impl Regex {
         let mut result = String::with_capacity(text.len());
         let mut last_end = 0;
 
-        for m in core::iter::once(first_match).chain(matches) {
+        result.push_str(&text[last_end..first_match.start()]);
+        self.expand_replacement(&first_match, text, replacement, &mut result);
+        last_end = first_match.end();
+
+        for m in matches {
             result.push_str(&text[last_end..m.start()]);
             self.expand_replacement(&m, text, replacement, &mut result);
             last_end = m.end();
@@ -654,7 +658,11 @@ impl Regex {
         let mut result = String::with_capacity(text.len());
         let mut last_end = 0;
 
-        for m in core::iter::once(first_match).chain(matches) {
+        result.push_str(&text[last_end..first_match.start()]);
+        result.push_str(&replacement(&first_match));
+        last_end = first_match.end();
+
+        for m in matches {
             result.push_str(&text[last_end..m.start()]);
             result.push_str(&replacement(&m));
             last_end = m.end();

--- a/src/api.rs
+++ b/src/api.rs
@@ -18,12 +18,10 @@ use crate::pikevm;
 use crate::util::to_char_sat;
 
 #[cfg(not(feature = "std"))]
-use alloc::{
-    boxed::Box,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{borrow::Cow, boxed::Box, string::String, vec::Vec};
 use core::{fmt, iter::FusedIterator, str::FromStr};
+#[cfg(feature = "std")]
+use std::borrow::Cow;
 
 pub use parse::Error;
 
@@ -520,7 +518,7 @@ impl Regex {
     /// where `$1` refers to the first capture group, `$2` to the second, and so on.
     /// `$0` refers to the entire match. Use `$$` to insert a literal `$`.
     ///
-    /// If no match is found, the original text is returned unchanged.
+    /// If no match is found, the original text is returned unchanged without allocation.
     ///
     /// # Examples
     ///
@@ -535,16 +533,16 @@ impl Regex {
     /// let result = re.replace("2023-12-25", "$2/$3/$1");
     /// assert_eq!(result, "12/25/2023");
     /// ```
-    pub fn replace(&self, text: &str, replacement: &str) -> String {
+    pub fn replace<'t>(&self, text: &'t str, replacement: &str) -> Cow<'t, str> {
         match self.find(text) {
             Some(m) => {
                 let mut result = String::with_capacity(text.len());
                 result.push_str(&text[..m.start()]);
                 self.expand_replacement(&m, text, replacement, &mut result);
                 result.push_str(&text[m.end()..]);
-                result
+                Cow::Owned(result)
             }
-            None => text.to_string(),
+            None => Cow::Borrowed(text),
         }
     }
 
@@ -553,6 +551,8 @@ impl Regex {
     /// The replacement string may contain capture group references in the form `$1`, `$2`, etc.,
     /// where `$1` refers to the first capture group, `$2` to the second, and so on.
     /// `$0` refers to the entire match. Use `$$` to insert a literal `$`.
+    ///
+    /// If no match is found, the original text is returned unchanged without allocation.
     ///
     /// # Examples
     ///
@@ -567,18 +567,23 @@ impl Regex {
     /// let result = re.replace_all("hello world", "$1.$2");
     /// assert_eq!(result, "h.ello w.orld");
     /// ```
-    pub fn replace_all(&self, text: &str, replacement: &str) -> String {
+    pub fn replace_all<'t>(&self, text: &'t str, replacement: &str) -> Cow<'t, str> {
+        let mut matches = self.find_iter(text);
+        let Some(first_match) = matches.next() else {
+            return Cow::Borrowed(text);
+        };
+
         let mut result = String::with_capacity(text.len());
         let mut last_end = 0;
 
-        for m in self.find_iter(text) {
+        for m in core::iter::once(first_match).chain(matches) {
             result.push_str(&text[last_end..m.start()]);
             self.expand_replacement(&m, text, replacement, &mut result);
             last_end = m.end();
         }
 
         result.push_str(&text[last_end..]);
-        result
+        Cow::Owned(result)
     }
 
     /// Replaces the first match of the regex in `text` using a closure.
@@ -586,7 +591,7 @@ impl Regex {
     /// The closure receives a `&Match` and should return the replacement string.
     /// This is useful for dynamic replacements that depend on the match details.
     ///
-    /// If no match is found, the original text is returned unchanged.
+    /// If no match is found, the original text is returned unchanged without allocation.
     ///
     /// # Examples
     ///
@@ -601,7 +606,7 @@ impl Regex {
     /// });
     /// assert_eq!(result, "Price: $246");
     /// ```
-    pub fn replace_with<F>(&self, text: &str, replacement: F) -> String
+    pub fn replace_with<'t, F>(&self, text: &'t str, replacement: F) -> Cow<'t, str>
     where
         F: FnOnce(&Match) -> String,
     {
@@ -611,9 +616,9 @@ impl Regex {
                 result.push_str(&text[..m.start()]);
                 result.push_str(&replacement(&m));
                 result.push_str(&text[m.end()..]);
-                result
+                Cow::Owned(result)
             }
-            None => text.to_string(),
+            None => Cow::Borrowed(text),
         }
     }
 
@@ -621,6 +626,8 @@ impl Regex {
     ///
     /// The closure receives a `&Match` and should return the replacement string.
     /// This is useful for dynamic replacements that depend on the match details.
+    ///
+    /// If no match is found, the original text is returned unchanged without allocation.
     ///
     /// # Examples
     ///
@@ -635,21 +642,26 @@ impl Regex {
     /// });
     /// assert_eq!(result, "Items: [50], [100], [150]");
     /// ```
-    pub fn replace_all_with<F>(&self, text: &str, replacement: F) -> String
+    pub fn replace_all_with<'t, F>(&self, text: &'t str, replacement: F) -> Cow<'t, str>
     where
         F: Fn(&Match) -> String,
     {
+        let mut matches = self.find_iter(text);
+        let Some(first_match) = matches.next() else {
+            return Cow::Borrowed(text);
+        };
+
         let mut result = String::with_capacity(text.len());
         let mut last_end = 0;
 
-        for m in self.find_iter(text) {
+        for m in core::iter::once(first_match).chain(matches) {
             result.push_str(&text[last_end..m.start()]);
             result.push_str(&replacement(&m));
             last_end = m.end();
         }
 
         result.push_str(&text[last_end..]);
-        result
+        Cow::Owned(result)
     }
 
     /// Helper method to expand replacement strings with capture group substitutions.

--- a/tests/replacement_tests.rs
+++ b/tests/replacement_tests.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use regress::Regex;
 
 #[test]
@@ -12,6 +14,15 @@ fn test_replace_no_match() {
     let re = Regex::new(r"xyz").unwrap();
     let result = re.replace("hello world", "universe");
     assert_eq!(result, "hello world");
+    assert!(matches!(result, Cow::Borrowed("hello world")));
+}
+
+#[test]
+fn test_replace_match_returns_owned() {
+    let re = Regex::new(r"world").unwrap();
+    let result = re.replace("hello world", "universe");
+    assert_eq!(result, "hello universe");
+    assert!(matches!(result, Cow::Owned(_)));
 }
 
 #[test]
@@ -50,6 +61,14 @@ fn test_replace_all_basic() {
 }
 
 #[test]
+fn test_replace_all_no_match_returns_borrowed() {
+    let re = Regex::new(r"\d+").unwrap();
+    let result = re.replace_all("abc", "X");
+    assert_eq!(result, "abc");
+    assert!(matches!(result, Cow::Borrowed("abc")));
+}
+
+#[test]
 fn test_replace_all_with_groups() {
     let re = Regex::new(r"(\w+)\s+(\w+)").unwrap();
     let result = re.replace_all("hello world foo bar", "$2-$1");
@@ -75,6 +94,14 @@ fn test_replace_with_closure() {
 }
 
 #[test]
+fn test_replace_with_no_match_returns_borrowed() {
+    let re = Regex::new(r"\d+").unwrap();
+    let result = re.replace_with("Price unavailable", |_| "unused".to_string());
+    assert_eq!(result, "Price unavailable");
+    assert!(matches!(result, Cow::Borrowed("Price unavailable")));
+}
+
+#[test]
 fn test_replace_all_with_closure() {
     let re = Regex::new(r"\d+").unwrap();
     let text = "Items: 5, 10, 15";
@@ -83,6 +110,14 @@ fn test_replace_all_with_closure() {
         format!("[{}]", num * 10)
     });
     assert_eq!(result, "Items: [50], [100], [150]");
+}
+
+#[test]
+fn test_replace_all_with_no_match_returns_borrowed() {
+    let re = Regex::new(r"\d+").unwrap();
+    let result = re.replace_all_with("Items: none", |_| "unused".to_string());
+    assert_eq!(result, "Items: none");
+    assert!(matches!(result, Cow::Borrowed("Items: none")));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Return `Cow<'_, str>` from replacement APIs so no-match replacements can borrow the original input
- Avoid eager `String` allocation in `replace_all` and `replace_all_with` by checking for the first match before building output
- Add tests asserting no-match replacements return `Cow::Borrowed` and matched replacements return `Cow::Owned`

## Depends On

- #153

This branch is rebased on top of the cleanup changes from #153.

## Breaking Change

This changes the public return type of `replace`, `replace_all`, `replace_with`, and `replace_all_with` from `String` to `Cow<'_, str>`.

## Notes

Callers that need an owned `String` can use `.into_owned()`.