### PR TITLE
Apply clippy and rustfmt cleanup

### DIFF
--- a/gen-unicode/src/binary_properties.rs
+++ b/gen-unicode/src/binary_properties.rs
@@ -38,7 +38,7 @@ impl GenUnicode {
             ));
 
             self.scope
-                .new_fn(&format!("{}_ranges", orig_name.to_lowercase()))
+                .new_fn(format!("{}_ranges", orig_name.to_lowercase()))
                 .vis("pub(crate)")
                 .ret("&'static [Interval]")
                 .line(format!("&{}", orig_name.to_uppercase()))
@@ -141,7 +141,7 @@ impl GenUnicode {
             let chars = ucd_file.chars(orig_name, self);
 
             self.scope_tests
-                .new_fn(&format!(
+                .new_fn(format!(
                     "unicode_escape_property_binary_{}",
                     name.to_lowercase()
                 ))
@@ -151,7 +151,7 @@ impl GenUnicode {
                     name.to_lowercase()
                 ));
 
-            let f = self.scope_tests.new_fn(&format!(
+            let f = self.scope_tests.new_fn(format!(
                 "unicode_escape_property_binary_{}_tc",
                 name.to_lowercase()
             ));

--- a/gen-unicode/src/general_category_values.rs
+++ b/gen-unicode/src/general_category_values.rs
@@ -46,7 +46,7 @@ impl GenUnicode {
             ));
 
             self.scope
-                .new_fn(&format!("{}_ranges", orig_name.to_lowercase()))
+                .new_fn(format!("{}_ranges", orig_name.to_lowercase()))
                 .vis("pub(crate)")
                 .ret("&'static [Interval]")
                 .line(format!("&{}", orig_name.to_uppercase()))
@@ -93,7 +93,7 @@ impl GenUnicode {
             ));
 
             self.scope
-                .new_fn(&format!("{}_ranges", orig_name.to_lowercase()))
+                .new_fn(format!("{}_ranges", orig_name.to_lowercase()))
                 .vis("pub(crate)")
                 .ret("&'static [Interval]")
                 .line(format!("&{}", orig_name.to_uppercase()))
@@ -151,7 +151,7 @@ impl GenUnicode {
             char_map.insert(orig_name, chars.clone());
 
             self.scope_tests
-                .new_fn(&format!(
+                .new_fn(format!(
                     "unicode_escape_property_gc_{}",
                     name.to_lowercase()
                 ))
@@ -161,7 +161,7 @@ impl GenUnicode {
                     name.to_lowercase()
                 ));
 
-            let f = self.scope_tests.new_fn(&format!(
+            let f = self.scope_tests.new_fn(format!(
                 "unicode_escape_property_gc_{}_tc",
                 name.to_lowercase()
             ));
@@ -225,7 +225,7 @@ impl GenUnicode {
             }
 
             self.scope_tests
-                .new_fn(&format!(
+                .new_fn(format!(
                     "unicode_escape_property_gc_{}",
                     name.to_lowercase()
                 ))
@@ -235,7 +235,7 @@ impl GenUnicode {
                     name.to_lowercase()
                 ));
 
-            let f = self.scope_tests.new_fn(&format!(
+            let f = self.scope_tests.new_fn(format!(
                 "unicode_escape_property_gc_{}_tc",
                 name.to_lowercase()
             ));

--- a/gen-unicode/src/scripts.rs
+++ b/gen-unicode/src/scripts.rs
@@ -242,7 +242,7 @@ impl GenUnicode {
             let test_name = script.long.to_lowercase();
 
             self.scope_tests
-                .new_fn(&format!("unicode_escape_property_script_{test_name}"))
+                .new_fn(format!("unicode_escape_property_script_{test_name}"))
                 .attr("test")
                 .line(format!(
                     "test_with_configs(unicode_escape_property_script_{test_name}_tc)"
@@ -250,7 +250,7 @@ impl GenUnicode {
 
             let f = self
                 .scope_tests
-                .new_fn(&format!("unicode_escape_property_script_{test_name}_tc"))
+                .new_fn(format!("unicode_escape_property_script_{test_name}_tc"))
                 .arg("tc", "TestConfig");
 
             // Exclude surrogate code points (U+D800..U+DFFF) — they are not valid

--- a/gen-unicode/src/string_properties.rs
+++ b/gen-unicode/src/string_properties.rs
@@ -124,7 +124,7 @@ impl GenUnicode {
             ));
 
             self.scope
-                .new_fn(&format!("{}_sets", name.to_lowercase()))
+                .new_fn(format!("{}_sets", name.to_lowercase()))
                 .vis("pub(crate)")
                 .ret("&'static [&'static [u32]]")
                 .line(format!("{}.as_slice()", name.to_uppercase()))

--- a/src/api.rs
+++ b/src/api.rs
@@ -17,15 +17,13 @@ use crate::{
 use crate::pikevm;
 use crate::util::to_char_sat;
 
-use core::{fmt, iter::FusedIterator, str::FromStr};
 #[cfg(not(feature = "std"))]
-use {
-    alloc::{
-        boxed::Box,
-        string::{String, ToString},
-        vec::Vec,
-    },
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
 };
+use core::{fmt, iter::FusedIterator, str::FromStr};
 
 pub use parse::Error;
 

--- a/src/classicalbacktrack.rs
+++ b/src/classicalbacktrack.rs
@@ -867,7 +867,10 @@ impl<'a, Input: InputIndexer> MatchAttempter<'a, Input> {
                         next_or_bt!(true)
                     }
 
-                    &Insn::BackRef { group: cg_idx, icase } => {
+                    &Insn::BackRef {
+                        group: cg_idx,
+                        icase,
+                    } => {
                         let cg = self.s.groups.mat(cg_idx as usize);
                         // Backreferences to a capture group that did not match always succeed (ES5
                         // 15.10.2.9).

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -7,9 +7,9 @@ use crate::ir::Node;
 use crate::startpredicate;
 use crate::types::{BracketContents, CaptureGroupID, LoopID};
 use crate::unicode;
-use core::convert::TryInto;
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, vec::Vec};
+use core::convert::TryInto;
 
 /// \return an anchor instruction for a given IR anchor.
 fn make_anchor(anchor_type: ir::AnchorType, multiline: bool) -> Insn {
@@ -327,7 +327,10 @@ impl Emitter {
                         });
                         stack.push(Emitter::Node(contents));
                     }
-                    &Node::WordBoundary { invert, unicode_icase } => {
+                    &Node::WordBoundary {
+                        invert,
+                        unicode_icase,
+                    } => {
                         if unicode_icase {
                             self.emit_insn(Insn::WordBoundaryUnicodeICase { invert })
                         } else {
@@ -337,7 +340,10 @@ impl Emitter {
                     &Node::BackRef { group, icase } => {
                         debug_assert!(group >= 1, "Group should not be zero");
                         // -1 because \1 matches the first capture group, which has index 0.
-                        self.emit_insn(Insn::BackRef { group: group - 1, icase })
+                        self.emit_insn(Insn::BackRef {
+                            group: group - 1,
+                            icase,
+                        })
                     }
 
                     Node::ByteSet(bytes) => self.emit_byte_set_insn(bytes),

--- a/src/insn.rs
+++ b/src/insn.rs
@@ -97,7 +97,10 @@ pub enum Insn {
     ResetCaptureGroup(CaptureGroupID),
 
     /// Perform a backreference match.
-    BackRef { group: u32, icase: bool },
+    BackRef {
+        group: u32,
+        icase: bool,
+    },
 
     /// Match the next character against the bracket contents, stored at the given index in the CompiledRegex.
     Bracket(usize),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1627,10 +1627,7 @@ where
                             } else {
                                 cps = unicode::add_icase_code_points(cps);
                             }
-                            Ok(ir::Node::Bracket(BracketContents {
-                                invert: false,
-                                cps,
-                            }))
+                            Ok(ir::Node::Bracket(BracketContents { invert: false, cps }))
                         } else {
                             Ok(ir::Node::Bracket(BracketContents {
                                 invert: negate,
@@ -1662,7 +1659,10 @@ where
             '1'..='9' if self.flags.unicode => {
                 let group = self.try_consume_decimal_integer_literal().unwrap();
                 if group <= self.group_count_max as usize {
-                    Ok(ir::Node::BackRef { group: group as u32, icase: self.flags.icase })
+                    Ok(ir::Node::BackRef {
+                        group: group as u32,
+                        icase: self.flags.icase,
+                    })
                 } else {
                     error("Invalid character escape")
                 }
@@ -1676,7 +1676,10 @@ where
                 let group = self.try_consume_decimal_integer_literal().unwrap();
 
                 if group <= self.group_count_max as usize {
-                    Ok(ir::Node::BackRef { group: group as u32, icase: self.flags.icase })
+                    Ok(ir::Node::BackRef {
+                        group: group as u32,
+                        icase: self.flags.icase,
+                    })
                 } else {
                     self.input = input;
                     let c = self.consume_character_escape()?;
@@ -1708,16 +1711,23 @@ where
                     0 => unreachable!("Should not have empty indices for group name"),
                     1 => {
                         // Common case of a backref matching a single group.
-                        ir::Node::BackRef { group: group_indices[0] + 1, icase: self.flags.icase }
+                        ir::Node::BackRef {
+                            group: group_indices[0] + 1,
+                            icase: self.flags.icase,
+                        }
                     }
                     _ => {
                         // Unusual case of multiple groups sharing a name: the backref should try each in turn.
                         // Lower to alternations of backreferences. Reverse to keep it right-associative: a | (b | (c | d))...
                         let icase = self.flags.icase;
-                        let backrefs = group_indices
-                            .iter()
-                            .rev()
-                            .map(|group_index| ir::Node::BackRef { group: *group_index + 1, icase });
+                        let backrefs =
+                            group_indices
+                                .iter()
+                                .rev()
+                                .map(|group_index| ir::Node::BackRef {
+                                    group: *group_index + 1,
+                                    icase,
+                                });
                         backrefs
                             .reduce(|right, left| ir::Node::Alt(Box::new(left), Box::new(right)))
                             .unwrap()

--- a/src/pikevm.rs
+++ b/src/pikevm.rs
@@ -221,7 +221,10 @@ fn try_match_state<Input: InputIndexer, Dir: Direction>(
             nextinsn_or_fail!(true)
         }
 
-        &Insn::BackRef { group: group_idx, icase } => {
+        &Insn::BackRef {
+            group: group_idx,
+            icase,
+        } => {
             let matched;
             let group = &mut s.groups[group_idx as usize];
             if let Some(orig_range) = group.as_range() {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -171,10 +171,10 @@ fn group_modifier_backref_icase_tc(tc: TestConfig) {
     // Backreference outside the modifier group should NOT inherit icase.
     // (?i:(a))\1 — \1 is outside (?i:...), so it must match the captured text exactly.
     let re = tc.compile(r"(?i:(a))\1");
-    assert!(re.find("aa").is_some());  // captures 'a', backref matches 'a'
-    assert!(re.find("AA").is_some());  // captures 'A', backref matches 'A'
-    assert!(re.find("aA").is_none());  // captures 'a', backref needs 'a' but gets 'A'
-    assert!(re.find("Aa").is_none());  // captures 'A', backref needs 'A' but gets 'a'
+    assert!(re.find("aa").is_some()); // captures 'a', backref matches 'a'
+    assert!(re.find("AA").is_some()); // captures 'A', backref matches 'A'
+    assert!(re.find("aA").is_none()); // captures 'a', backref needs 'a' but gets 'A'
+    assert!(re.find("Aa").is_none()); // captures 'A', backref needs 'A' but gets 'a'
 
     // Verify that without modifier group, global icase flag works on backrefs.
     let re = tc.compilef(r"(a)\1", "i");


### PR DESCRIPTION
## Summary

- Apply current `cargo clippy --fix --workspace` suggestions
- Apply `cargo fmt --all` formatting updates
- Keep this as a standalone cleanup branch based on `master`

