### PR TITLE
Fix testcase failure in big-endian machines

### DIFF
--- a/src/bytesearch.rs
+++ b/src/bytesearch.rs
@@ -279,9 +279,9 @@ impl ByteBitmap {
         }
 
         for &chunk in body {
-            // Use LE. Here index 0 is the earliest address.
-            let byte_idxs = ((chunk >> 4) & 0x0F0F0F0F).to_le_bytes();
-            let bit_idxs = (chunk & 0x0F0F0F0F).to_le_bytes();
+            // Use native endian to match memory layout. Here index 0 is the earliest address.
+            let byte_idxs = ((chunk >> 4) & 0x0F0F0F0F).to_ne_bytes();
+            let bit_idxs = (chunk & 0x0F0F0F0F).to_ne_bytes();
             if (bm[byte_idxs[0] as usize] & (1 << bit_idxs[0])) != 0 {
                 return Some(offset);
             }


### PR DESCRIPTION
The test `bytesearch::tests::bitmap_search` was failing on s390x (big endian architecture)
(https://buildd.debian.org/status/fetch.php?pkg=rust-regress&arch=s390x&ver=0.10.5-1%2Bb1&stamp=1772159432&raw=0)

```
---- bytesearch::tests::bitmap_search stdout ----

thread 'bytesearch::tests::bitmap_search' (1218) panicked at src/bytesearch.rs:377:9:
assertion `left == right` failed
  left: Some(5)
 right: Some(6)
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /usr/src/rustc-1.95.0/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_fmt
             at /usr/src/rustc-1.95.0/library/core/src/panicking.rs:80:14
   2: core::panicking::assert_failed_inner
             at /usr/src/rustc-1.95.0/library/core/src/panicking.rs:439:17
   3: core::panicking::assert_failed::<core::option::Option<usize>, core::option::Option<usize>>
             at /usr/src/rustc-1.95.0/library/core/src/panicking.rs:394:5
   4: regress::bytesearch::tests::bitmap_search
             at /usr/share/cargo/registry/regress-0.10.5/src/bytesearch.rs:377:9
   5: regress::bytesearch::tests::bitmap_search::{{closure}}
             at /usr/share/cargo/registry/regress-0.10.5/src/bytesearch.rs:364:23
   6: core::ops::function::FnOnce::call_once
             at /usr/src/rustc-1.95.0/library/core/src/ops/function.rs:250:5
   7: <fn() -> core::result::Result<(), alloc::string::String> as core::ops::function::FnOnce<()>>::call_once
             at /usr/src/rustc-1.95.0/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    bytesearch::tests::bitmap_search

test result: FAILED. 24 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 12.30s
```

Here in the code, `find_in` function has two implementations, one is a safe implementation and one is an unsafe implementation (Picks the unsafe implementation by default and the safe one if `prohibit-unsafe` feature is used). When testing both, the safe implementation works fine while the unsafe implementation fails on big-endian machines.
The unsafe implementation uses `align_to` to align a u8 array to u32 boundaries, splitting it into three parts: prefix (unaligned bytes before), body (aligned u32 chunks), and suffix (unaligned bytes after). The function processes prefix and suffix byte-by-byte, while body is processed in 4-byte chunks for performance.
The bug occurs in the body processing: after extracting nibbles using bit masks, the code converts the u32 values to byte arrays using `.to_le_bytes()`. On big-endian systems, this conversion produces bytes in reversed order relative to the memory layout, causing the byte indices to be extracted incorrectly. This results in checking the wrong bitmap positions. The fix is to change `.to_le_bytes()` to `.to_ne_bytes()` (native endian), which ensures the byte array indices match the actual memory layout regardless of system endianness. With this change, the tests pass on both little-endian and big-endian systems, with and without the prohibit-unsafe feature.