### PR TITLE
fix missing `v` flag in fmt::Display impl for Flags

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -101,17 +101,29 @@ impl From<&str> for Flags {
 
 impl fmt::Display for Flags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.multiline {
+        // Destrucutre so we don't forget to print a field if new ones are added.
+        let Self {
+            icase,
+            multiline,
+            dot_all,
+            no_opt: _,
+            unicode,
+            unicode_sets,
+        } = *self;
+        if multiline {
             f.write_str("m")?;
         }
-        if self.icase {
+        if icase {
             f.write_str("i")?;
         }
-        if self.dot_all {
+        if dot_all {
             f.write_str("s")?;
         }
-        if self.unicode {
+        if unicode {
             f.write_str("u")?;
+        }
+        if unicode_sets {
+            f.write_str("v")?;
         }
         Ok(())
     }


### PR DESCRIPTION
looks like it was never added with the original impl of `v` in https://github.com/ridiculousfish/regress/pull/90