### PR TITLE
refactor: avoid duplicating regex internals

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -397,7 +397,6 @@ impl Regex {
     /// An Error may be returned if the syntax is invalid.
     /// Note that this is rather expensive; prefer to cache a Regex which is
     /// intended to be used more than once.
-    #[inline]
     pub fn new(pattern: &str) -> Result<Regex, Error> {
         Self::with_flags(pattern, Flags::default())
     }
@@ -435,7 +434,6 @@ impl Regex {
     }
 
     /// Searches `text` to find the first match.
-    #[inline]
     pub fn find(&self, text: &str) -> Option<Match> {
         self.find_iter(text).next()
     }
@@ -480,7 +478,6 @@ impl Regex {
     /// Searches `text` to find the first match.
     /// The input text is expected to be ascii-only: only ASCII case-folding is
     /// supported.
-    #[inline]
     pub fn find_ascii(&self, text: &str) -> Option<Match> {
         self.find_iter_ascii(text).next()
     }


### PR DESCRIPTION
`#[inline]` created two transitive inline chains:

- [`Regex::new`](https://github.com/ridiculousfish/regress/blob/1621a47cb0cf679a492ac8a88efa816d1640febb/src/api.rs#L400-L403) → [`with_flags`](https://github.com/ridiculousfish/regress/blob/1621a47cb0cf679a492ac8a88efa816d1640febb/src/api.rs#L410-L416) → [`from_unicode`](https://github.com/ridiculousfish/regress/blob/1621a47cb0cf679a492ac8a88efa816d1640febb/src/api.rs#L423-L434) → parser, optimizer, and emitter.
- [`Regex::find`](https://github.com/ridiculousfish/regress/blob/1621a47cb0cf679a492ac8a88efa816d1640febb/src/api.rs#L438-L441) → [`find_iter`](https://github.com/ridiculousfish/regress/blob/1621a47cb0cf679a492ac8a88efa816d1640febb/src/api.rs#L446-L449) → [`find_from`](https://github.com/ridiculousfish/regress/blob/1621a47cb0cf679a492ac8a88efa816d1640febb/src/api.rs#L471-L478) → [`Matches::next`](https://github.com/ridiculousfish/regress/blob/1621a47cb0cf679a492ac8a88efa816d1640febb/src/exec.rs#L50-L55) → matcher.

These chains were copied into both `pnp` and `oxc_resolver_napi`. Removing the top-level annotations lets them share one implementation.

In oxc-resolver’s NAPI cdylib, Mach-O `__text` decreases from 1,077,744 B to 1,003,492 B (-72.5 KiB).