### PR TITLE
Add an optional backtracking budget

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -141,6 +141,16 @@ pub type Matches<'r, 't> = exec::Matches<backends::DefaultExecutor<'r, 't>>;
 pub type AsciiMatches<'r, 't> = exec::Matches<backends::DefaultAsciiExecutor<'r, 't>>;
 
 /// A Match represents a portion of a string which was found to match a Regex.
+/// The outcome of a budgeted search — see [`Regex::find_from_budgeted`].
+pub enum BudgetedMatch {
+    /// A match was found.
+    Match(Match),
+    /// The search completed and there is no match.
+    NoMatch,
+    /// The backtracking budget ran out; the answer is unknown.
+    BudgetExhausted,
+}
+
 #[derive(Debug, Clone)]
 pub struct Match {
     /// The total range of the match. Note this may be empty, if the regex
@@ -436,6 +446,43 @@ impl Regex {
     /// Searches `text` to find the first match.
     pub fn find(&self, text: &str) -> Option<Match> {
         self.find_iter(text).next()
+    }
+
+    /// Search `text` from byte offset `start`, giving up after `budget`
+    /// backtracks.
+    ///
+    /// A classical backtracker has no bound on the work one search can do —
+    /// `/^(a+)+$/` against `"a" * n + "!"` doubles with each added character —
+    /// so an engine used on untrusted patterns or untrusted input needs a way
+    /// to stop. Returns [`BudgetedMatch::BudgetExhausted`] rather than a wrong
+    /// `None`, because "I gave up" and "there is no match" call for different
+    /// responses from the caller.
+    ///
+    /// The budget is per call; [`Regex::find`] and the iterators are
+    /// unaffected and stay unbudgeted.
+    ///
+    /// ```rust
+    /// use regress::{BudgetedMatch, Regex};
+    /// let re = Regex::new(r"^(a+)+$").unwrap();
+    /// let hay = "a".repeat(40) + "!";
+    /// assert!(matches!(
+    ///     re.find_from_budgeted(&hay, 0, 100_000),
+    ///     BudgetedMatch::BudgetExhausted
+    /// ));
+    /// ```
+    pub fn find_from_budgeted(&self, text: &str, start: usize, budget: u64) -> BudgetedMatch {
+        use crate::exec::{Executor, MatchProducer};
+        let mut exec = <backends::DefaultExecutor as Executor>::new(&self.cr, text);
+        exec.set_backtrack_budget(budget);
+        let Some(pos) = exec.initial_position(start) else {
+            return BudgetedMatch::NoMatch;
+        };
+        let mut next_start = None;
+        match exec.next_match(pos, &mut next_start) {
+            Some(m) => BudgetedMatch::Match(m),
+            None if exec.budget_exhausted() => BudgetedMatch::BudgetExhausted,
+            None => BudgetedMatch::NoMatch,
+        }
     }
 
     /// Searches `text`, returning an iterator over non-overlapping matches.

--- a/src/classicalbacktrack.rs
+++ b/src/classicalbacktrack.rs
@@ -73,6 +73,12 @@ pub(crate) struct MatchAttempter<'a, Input: InputIndexer> {
     re: &'a CompiledRegex,
     bts: Vec<BacktrackInsn<Input>>,
     s: State<Input::Position>,
+    /// Backtracking steps left before this attempter gives up, or `u64::MAX`
+    /// for "unlimited" — the default, and the historical behaviour.
+    budget: u64,
+    /// Set when [`Self::budget`] ran out during the last attempt, so a caller
+    /// can tell "gave up" apart from "no match".
+    pub(crate) budget_exhausted: bool,
 }
 
 impl<'a, Input: InputIndexer> MatchAttempter<'a, Input> {
@@ -84,12 +90,38 @@ impl<'a, Input: InputIndexer> MatchAttempter<'a, Input> {
                 loops: vec![LoopData::new(entry); re.loops as usize],
                 groups: vec![GroupData::new(); re.groups as usize],
             },
+            budget: u64::MAX,
+            budget_exhausted: false,
         }
+    }
+
+    /// Limit how many backtracks one match attempt may take. `u64::MAX` (the
+    /// default) is unlimited.
+    pub(crate) fn set_backtrack_budget(&mut self, budget: u64) {
+        self.budget = budget;
     }
 
     #[inline(always)]
     fn push_backtrack(&mut self, bt: BacktrackInsn<Input>) {
         self.bts.push(bt)
+    }
+
+    /// Charge one backtrack against the budget.
+    ///
+    /// `false` means the budget is spent and the attempt must unwind. Charged
+    /// on the backtrack path, not the instruction path: forward progress is
+    /// bounded by the subject, only backtracking is not.
+    #[inline(always)]
+    fn charge_backtrack(&mut self) -> bool {
+        if self.budget == u64::MAX {
+            return true;
+        }
+        if self.budget == 0 {
+            self.budget_exhausted = true;
+            return false;
+        }
+        self.budget -= 1;
+        true
     }
 
     #[inline(always)]
@@ -980,6 +1012,14 @@ impl<'a, Input: InputIndexer> MatchAttempter<'a, Input> {
 
             // This after the backtrack loop.
             // A break 'backtrack will jump here.
+            //
+            // The one place a backtrack is taken, so the one place to charge
+            // the budget. Running out unwinds to the sentinel and reports no
+            // match, with `budget_exhausted` set.
+            if !self.charge_backtrack() {
+                self.bts.truncate(1);
+                return None;
+            }
             if self.try_backtrack(input, &mut ip, &mut pos, dir) {
                 continue 'nextinsn;
             } else {
@@ -1089,6 +1129,20 @@ impl<Input: InputIndexer> BacktrackExecutor<'_, Input> {
             // Didn't find it at this position, try the next one.
             pos = inp.next_right_pos(pos)?;
         }
+    }
+}
+
+impl<Input: InputIndexer> BacktrackExecutor<'_, Input> {
+    /// Limit how many backtracks one search may take. `u64::MAX` (the default)
+    /// is unlimited.
+    pub fn set_backtrack_budget(&mut self, budget: u64) {
+        self.matcher.set_backtrack_budget(budget);
+    }
+
+    /// Did the last search stop because the budget ran out rather than because
+    /// there is no match?
+    pub fn budget_exhausted(&self) -> bool {
+        self.matcher.budget_exhausted
     }
 }
 

--- a/tests/backtrack_budget.rs
+++ b/tests/backtrack_budget.rs
@@ -1,0 +1,69 @@
+//! A backtracking budget bounds the work one search may do.
+
+use regress::{BudgetedMatch, Regex};
+
+/// The canonical exponential shape. Unbudgeted this takes minutes at n = 40;
+/// with a budget it returns immediately and says so.
+#[test]
+fn exponential_pattern_reports_exhaustion_instead_of_running_away() {
+    let re = Regex::new(r"^(a+)+$").unwrap();
+    let hay = "a".repeat(40) + "!";
+    assert!(matches!(
+        re.find_from_budgeted(&hay, 0, 100_000),
+        BudgetedMatch::BudgetExhausted
+    ));
+}
+
+/// A budget generous enough for the search leaves the answer alone — both the
+/// match and the no-match case, and the capture spans with them.
+#[test]
+fn a_sufficient_budget_does_not_change_the_answer() {
+    let re = Regex::new(r"(\w+)@(\w+)\.com").unwrap();
+    match re.find_from_budgeted("mail me at bob@example.com ok", 0, 1_000_000) {
+        BudgetedMatch::Match(m) => {
+            assert_eq!(m.range(), 11..26);
+            assert_eq!(m.group(1), Some(11..14));
+            assert_eq!(m.group(2), Some(15..22));
+        }
+        other => panic!(
+            "expected a match, got {:?}",
+            matches!(other, BudgetedMatch::NoMatch)
+        ),
+    }
+    assert!(matches!(
+        re.find_from_budgeted("nothing here", 0, 1_000_000),
+        BudgetedMatch::NoMatch
+    ));
+}
+
+/// The budget is per search, not per process: an exhausted search does not
+/// poison a later one, and `find` itself stays unbudgeted.
+#[test]
+fn the_budget_is_per_search() {
+    let re = Regex::new(r"^(a+)+$").unwrap();
+    let hay = "a".repeat(40) + "!";
+    assert!(matches!(
+        re.find_from_budgeted(&hay, 0, 1_000),
+        BudgetedMatch::BudgetExhausted
+    ));
+    assert!(matches!(
+        re.find_from_budgeted("aaaa", 0, 1_000),
+        BudgetedMatch::Match(_)
+    ));
+    assert!(Regex::new("ab").unwrap().find("xxabxx").is_some());
+}
+
+/// `start` behaves as it does for `find_from` — offsets are absolute and
+/// lookbehind sees the text before them.
+#[test]
+fn budgeted_search_honours_the_start_offset() {
+    let re = Regex::new(r"(?<=x)y").unwrap();
+    assert!(matches!(
+        re.find_from_budgeted("xyxy", 1, 1_000_000),
+        BudgetedMatch::Match(_)
+    ));
+    match re.find_from_budgeted("xyxy", 2, 1_000_000) {
+        BudgetedMatch::Match(m) => assert_eq!(m.range(), 3..4),
+        _ => panic!("expected the second occurrence"),
+    }
+}


### PR DESCRIPTION
## Why

A classical backtracker has no bound on the work one search can do. `/^(a+)+$/`
against `"a" * n + "!"` doubles with every added character, so 28 characters
already takes seconds and 40 takes minutes. Anything that runs untrusted
patterns, or trusted patterns over untrusted input, therefore needs a way to
stop — and today `regress` offers none.

That matters more for this crate than for a linear-time engine, because
`regress` is chosen precisely where ECMAScript semantics are required, which
tends to mean "running the patterns a JavaScript program happens to contain".

## What

`Regex::find_from_budgeted(text, start, budget) -> BudgetedMatch`.

The budget is charged one unit per **backtrack**, at the single dispatch point
in `try_at_pos` — backtracking is the quantity that explodes; forward progress
is already bounded by the subject. Running out unwinds to the sentinel and
reports:

```rust
pub enum BudgetedMatch {
    Match(Match),
    NoMatch,
    BudgetExhausted,
}
```

`BudgetExhausted` rather than a wrong `None` is the point of the API: "I gave
up" and "there is no match" call for different responses, and a caller that
can fall back to another engine should not be handed an answer that is not
true.

Opt-in and per call. `MatchAttempter::budget` defaults to `u64::MAX`; `find`,
`find_from` and the iterators are untouched and stay unbudgeted. On the
unbudgeted path the charge is one comparison against that sentinel, on a branch
that already exists.

## Measurements

Corpus: **4,463 distinct regex literals** extracted with a real JS lexer from
seven production bundles (two builds of a large TypeScript CLI, ethers.js,
moment, dayjs, luxon, mongodb-connection-string-url), plus a set of 26
known-pathological patterns — classic nested quantifiers, the usual
email/URL validators, giant alternations, deep nesting.

Worst single search and total, unbudgeted vs budgeted:

| corpus | budget | worst search | unbudgeted worst | hit budget | **answers changed** |
|---|---|---|---|---|---|
| pathological (26 × 3 subjects) | 10,000 | 0.2 ms | 45,504 ms | 27 | 0 |
| pathological | 100,000 | 4.9 ms | 61,131 ms | 24 | 0 |
| pathological | **1,000,000** | **123.8 ms** | **51,403 ms** | 20 | **0** |
| real literals (4,463 × 3 subjects) | 10,000 | 66.1 ms | 335.1 ms | 138 | **4** |
| real literals | 100,000 | 50.6 ms | 318.3 ms | 17 | 0 |
| real literals | **1,000,000** | 117.6 ms | 356.9 ms | 11 | **0** |

"answers changed" counts searches where exhaustion turned a match into a
non-match. Read together: **1,000,000 bounds the worst pathological search at
124 ms instead of 51 s (415×) and changes nothing about 13,389 real searches**;
10,000 is too aggressive to recommend as a default, since it changes four. For
calibration, 1,000,000 is also what `fancy-regex` ships as its default
`backtrack_limit`.

I have deliberately not made any budget the default — that is your call, and
the API is useful without one.

## Checks

* `cargo test --release`: **544 tests across 14 binaries, 0 failures**,
  unchanged from `master`.
* `cargo clippy --release --all-targets`: clean.
* `cargo fmt --check`: clean.
* New `tests/backtrack_budget.rs`: exhaustion on the exponential shape, a
  sufficient budget leaving match/no-match and capture spans identical, the
  budget being per-search rather than per-process, and `start` behaving as it
  does for `find_from` (including lookbehind seeing text before the offset).

101 lines added, 0 removed, across `src/classicalbacktrack.rs` and
`src/api.rs`.
